### PR TITLE
Log enqueueing of jobs

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -241,6 +241,14 @@ class Job(object):
                       kwargs=kwargs, priority=priority, eta=eta,
                       max_retries=max_retries, description=description)
         new_job.store()
+        _logger.debug(
+            "enqueued %s:%s(*%r, **%r) with uuid: %s",
+            new_job.recordset,
+            new_job.method_name,
+            new_job.args,
+            new_job.kwargs,
+            new_job.uuid
+        )
         return new_job
 
     @staticmethod


### PR DESCRIPTION
Useful for debugging if jobs when we want to know if and when a job is
being enqueued. It will log something like:

`odoo.addons.queue_job.job: enqueued model.name(1, 2, 3, ):method_name(*(arg1, arg2, ...), **{'kwarg1': 'value1', 'kwarg2': 'value2', ...}) with uuid: fdec21f5-7579-49b3-a80c-1ba91a6f3cfa`