### PR TITLE
Rationalize Job properties

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -3,7 +3,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.2.0.0',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue/queue_job',
  'license': 'AGPL-3',

--- a/test_queue_job/tests/test_related_actions.py
+++ b/test_queue_job/tests/test_related_actions.py
@@ -18,7 +18,7 @@ class TestRelatedAction(common.TransactionCase):
         """ Job with related action check if action returns correctly """
         job = Job(self.method)
         act_job, act_kwargs = job.related_action()
-        self.assertEqual(act_job, job.db_record())
+        self.assertEqual(act_job, job.db_record)
         self.assertEqual(act_kwargs, {})
 
     def test_no_related_action(self):
@@ -35,7 +35,7 @@ class TestRelatedAction(common.TransactionCase):
     def test_kwargs(self):
         """ Job with related action check if action propagates kwargs """
         job_ = Job(self.model.testing_related_action__kwargs)
-        self.assertEqual(job_.related_action(), (job_.db_record(), {'b': 4}))
+        self.assertEqual(job_.related_action(), (job_.db_record, {'b': 4}))
 
     def test_store_related_action(self):
         """ Call the related action on the model """


### PR DESCRIPTION
 - Extract the Job storage model attribute and use it consistently.

 - Turn `.dbrecord` and `.uuid` into their own auto-cached properties. Make them slightly better performant in the process.

I suggest evaluating one commit at a time.