### PR TITLE
[10.0] [IMP] Allow to override the channel to use when delaying a job

### DIFF
--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -25,7 +25,8 @@ class Base(models.AbstractModel):
 
     @api.multi
     def with_delay(self, priority=None, eta=None,
-                   max_retries=None, description=None):
+                   max_retries=None, description=None,
+                   channel=None):
         """ Return a ``DelayableRecordset``
 
         The returned instance allow to enqueue any method of the recordset's
@@ -48,6 +49,9 @@ class Base(models.AbstractModel):
                             infinite retries.  Default is 5.
         :param description: human description of the job. If None, description
                             is computed from the function doc or name
+        :param channel: the complete name of the channel to use to process
+                        the function. If specified it overrides the one
+                        defined on the function
         :return: instance of a DelayableRecordset
         :rtype: :class:`odoo.addons.queue_job.job.DelayableRecordset`
 
@@ -55,4 +59,5 @@ class Base(models.AbstractModel):
         return DelayableRecordset(self, priority=priority,
                                   eta=eta,
                                   max_retries=max_retries,
-                                  description=description)
+                                  description=description,
+                                  channel=channel)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -492,6 +492,12 @@ class TestJobModel(common.TransactionCase):
         self.assertTrue(key_present)
         self.assertEqual(result['job_uuid'], test_job._uuid)
 
+    def test_override_channel(self):
+        delayable = self.env['test.queue.job'].with_delay(
+            channel='root.sub.sub')
+        test_job = delayable.testing_method(return_context=True)
+        self.assertEqual('root.sub.sub', test_job.channel)
+
 
 class TestJobStorageMultiCompany(common.TransactionCase):
     """ Test storage of jobs """

--- a/test_queue_job/tests/test_job_channels.py
+++ b/test_queue_job/tests/test_job_channels.py
@@ -68,6 +68,8 @@ class TestJobChannels(common.TransactionCase):
         test_job.store()
         stored = self.env['queue.job'].search([('uuid', '=', test_job.uuid)])
         self.assertEquals(stored.channel, 'root')
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEquals(job_read.channel, 'root')
 
         channel = self.channel_model.create(
             {'name': 'sub', 'parent_id': self.root_channel.id}
@@ -78,6 +80,12 @@ class TestJobChannels(common.TransactionCase):
         test_job.store()
         stored = self.env['queue.job'].search([('uuid', '=', test_job.uuid)])
         self.assertEquals(stored.channel, 'root.sub')
+
+        # it's also possible to override the channel
+        test_job = Job(method, channel='root.sub.sub.sub')
+        test_job.store()
+        stored = self.env['queue.job'].search([('uuid', '=', test_job.uuid)])
+        self.assertEquals(stored.channel, test_job.channel)
 
     def test_default_channel(self):
         self.env['queue.job.function'].search([]).unlink()


### PR DESCRIPTION
The idea is to be able to specify the channel to use when delaying the job. 
```python
delayable = self.env['test.queue.job'].with_delay(channel='root.sub.sub')
```
If a channel is given as parameter to the `with_delay`method, it's used in place of the one declared as default_channel on the function to delay.