### PR TITLE
Allow to use datetime and date in job arguments

### DIFF
--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -3,6 +3,9 @@
 # license agpl-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import json
+from datetime import datetime, date
+
+import dateutil
 
 from odoo import fields, models
 
@@ -32,6 +35,12 @@ class JobEncoder(json.JSONEncoder):
             return {'_type': 'odoo_recordset',
                     'model': obj._name,
                     'ids': obj.ids}
+        elif isinstance(obj, datetime):
+            return {'_type': 'datetime_isoformat',
+                    'value': obj.isoformat()}
+        elif isinstance(obj, date):
+            return {'_type': 'date_isoformat',
+                    'value': obj.isoformat()}
         return json.JSONEncoder.default(self, obj)
 
 
@@ -52,4 +61,8 @@ class JobDecoder(json.JSONDecoder):
         type_ = obj['_type']
         if type_ == 'odoo_recordset':
             return self.env[obj['model']].browse(obj['ids'])
+        elif type_ == 'datetime_isoformat':
+            return dateutil.parser.parse(obj['value'])
+        elif type_ == 'date_isoformat':
+            return dateutil.parser.parse(obj['value']).date()
         return obj

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -2,6 +2,7 @@
 # copyright 2016 Camptocamp
 # license agpl-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from datetime import datetime, date
 import json
 
 from odoo.tests import common
@@ -10,16 +11,44 @@ from odoo.addons.queue_job.fields import JobEncoder, JobDecoder
 
 class TestJson(common.TransactionCase):
 
-    def test_encoder(self):
+    def test_encoder_recordset(self):
         value = ['a', 1, self.env.ref('base.user_root')]
         value_json = json.dumps(value, cls=JobEncoder)
         expected = ('["a", 1, {"_type": "odoo_recordset", '
                     '"model": "res.users", "ids": [1]}]')
         self.assertEqual(value_json, expected)
 
-    def test_decoder(self):
+    def test_decoder_recordset(self):
         value_json = ('["a", 1, {"_type": "odoo_recordset",'
                       '"model": "res.users", "ids": [1]}]')
         expected = ['a', 1, self.env.ref('base.user_root')]
+        value = json.loads(value_json, cls=JobDecoder, env=self.env)
+        self.assertEqual(value, expected)
+
+    def test_encoder_datetime(self):
+        value = ['a', 1, datetime(2017, 4, 19, 8, 48, 50, 1)]
+        value_json = json.dumps(value, cls=JobEncoder)
+        expected = ('["a", 1, {"_type": "datetime_isoformat", '
+                    '"value": "2017-04-19T08:48:50.000001"}]')
+        self.assertEqual(value_json, expected)
+
+    def test_decoder_datetime(self):
+        value_json = ('["a", 1, {"_type": "datetime_isoformat",'
+                      '"value": "2017-04-19T08:48:50.000001"}]')
+        expected = ['a', 1, datetime(2017, 4, 19, 8, 48, 50, 1)]
+        value = json.loads(value_json, cls=JobDecoder, env=self.env)
+        self.assertEqual(value, expected)
+
+    def test_encoder_date(self):
+        value = ['a', 1, date(2017, 4, 19)]
+        value_json = json.dumps(value, cls=JobEncoder)
+        expected = ('["a", 1, {"_type": "date_isoformat", '
+                    '"value": "2017-04-19"}]')
+        self.assertEqual(value_json, expected)
+
+    def test_decoder_date(self):
+        value_json = ('["a", 1, {"_type": "date_isoformat",'
+                      '"value": "2017-04-19"}]')
+        expected = ['a', 1, date(2017, 4, 19)]
         value = json.loads(value_json, cls=JobDecoder, env=self.env)
         self.assertEqual(value, expected)


### PR DESCRIPTION
Add JSON encoder and decoder for datetime and date values in the jobs so
we can use these types in job arguments.