### PR TITLE
[ADD] tests for queue job subscribe

### DIFF
--- a/setup/test_queue_job_subscription/odoo/__init__.py
+++ b/setup/test_queue_job_subscription/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/test_queue_job_subscription/odoo/addons/__init__.py
+++ b/setup/test_queue_job_subscription/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/test_queue_job_subscription/odoo/addons/test_queue_job_subscription
+++ b/setup/test_queue_job_subscription/odoo/addons/test_queue_job_subscription
@@ -1,0 +1,1 @@
+../../../../test_queue_job_subscription

--- a/setup/test_queue_job_subscription/setup.py
+++ b/setup/test_queue_job_subscription/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test_queue_job_subscription/README.rst
+++ b/test_queue_job_subscription/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+Test Job Queue
+==============
+
+This addon is not meant to be used. It extends the Odoo Models
+in order to run automated tests on the queue jobs subscribe.
+
+We use job methods that are integrated with the ``test_queue_job`` addon.
+
+Installation
+============
+
+Nothing particular.
+
+Usage
+=====
+
+This module only contains Python tests.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/connector/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Meyomesse Gilles <meyomesse.gilles@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/test_queue_job_subscription/__init__.py
+++ b/test_queue_job_subscription/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Gilles Meyomesse
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import tests

--- a/test_queue_job_subscription/__manifest__.py
+++ b/test_queue_job_subscription/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Connector Job Subscribe Tests',
+    'version': '10.0.1.0.0',
+    'author': 'ACSONE SA/NV',
+    'website': 'https://acsone.eu/',
+    'license': 'AGPL-3',
+    'category': 'Generic Modules',
+    'depends': ['queue_job_subscribe',
+                'test_queue_job',
+                ],
+    'installable': True,
+}

--- a/test_queue_job_subscription/tests/__init__.py
+++ b/test_queue_job_subscription/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Gilles Meyomesse
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_queue_job_subscribe

--- a/test_queue_job_subscription/tests/test_queue_job_subscribe.py
+++ b/test_queue_job_subscription/tests/test_queue_job_subscribe.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2017 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestQueueJobSubscribe(SavepointCase):
+    """
+        When a job is created, all user of group
+        connector.group_connector_manager are automatically set as
+        follower except if the flag subscribe_job is not set
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestQueueJobSubscribe, cls).setUpClass()
+
+        # MODELS
+        cls.queue_job = cls.env['queue.job']
+        cls.user = cls.env['res.users']
+        cls.company = cls.env['res.company']
+        cls.partner = cls.env['res.partner']
+
+        # INSTANCES
+        grp_queue_job_manager = cls.env.ref(
+            "queue_job.group_queue_job_manager")
+        cls.other_partner_a = cls.partner.create(
+            {"name": "My Company a",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        cls.other_company_a = cls.company.create(
+            {"name": "My Company a",
+             "partner_id": cls.other_partner_a.id,
+             "rml_header1": "My Company Tagline",
+             "currency_id": cls.env.ref("base.EUR").id
+             })
+        cls.other_user_a = cls.user.create(
+            {"partner_id": cls.other_partner_a.id,
+             "company_id": cls.other_company_a.id,
+             "company_ids": [(4, cls.other_company_a.id)],
+             "login": "my_login a",
+             "name": "my user",
+             "groups_id": [(4, grp_queue_job_manager.id)]
+             })
+        cls.other_partner_b = cls.partner.create(
+            {"name": "My Company b",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        cls.other_company_b = cls.company.create(
+            {"name": "My Company b",
+             "partner_id": cls.other_partner_b.id,
+             "rml_header1": "My Company Tagline",
+             "currency_id": cls.env.ref("base.EUR").id
+             })
+        cls.other_user_b = cls.user.create(
+            {"partner_id": cls.other_partner_b.id,
+             "company_id": cls.other_company_b.id,
+             "company_ids": [(4, cls.other_company_b.id)],
+             "login": "my_login_b",
+             "name": "my user 1",
+             "groups_id": [(4, grp_queue_job_manager.id)]
+             })
+
+    def _subscribe_users(self, stored):
+        domain = stored._subscribe_users_domain()
+        users = self.user.search(domain)
+        stored.message_subscribe_users(user_ids=users.ids)
+
+    def _create_job(self, env):
+        self.cr.execute('delete from queue_job')
+        env['test.queue.job'].with_delay().testing_method()
+        stored = self.queue_job.search([])
+        self.assertEqual(len(stored), 1)
+        return stored
+
+    def test_job_subscription_subscribe_job_checked(self):
+        #################################
+        # Test 1: All users are followers
+        #################################
+        no_company_context = dict(self.env.context, company_id=None)
+        no_company_env = self.env(context=no_company_context)
+        stored = self._create_job(no_company_env)
+        self._subscribe_users(stored)
+        users = self.user.search(
+            [('groups_id', '=', self.ref('queue_job.group_queue_job_manager')),
+             ('subscribe_job', '=', True)]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(
+            set(stored.message_follower_ids.mapped('partner_id')),
+            set(expected_partners))
+        followers_id = stored.message_follower_ids.mapped('partner_id.id')
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertIn(self.other_partner_b.id, followers_id)
+
+    def test_job_subscription_subscribe_job_unchecked(self):
+        ###########################################
+        # Test 2: User b request to not be follower
+        ###########################################
+        self.other_user_b.write({'subscribe_job': False})
+        no_company_context = dict(self.env.context, company_id=None)
+        no_company_env = self.env(context=no_company_context)
+        stored = self._create_job(no_company_env)
+        self._subscribe_users(stored)
+        users = self.user.search(
+            [('groups_id', '=', self.ref('connector.group_connector_manager')),
+             ('subscribe_job', '=', True)]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(set(stored.mapped(
+            'message_follower_ids.partner_id')),
+            set(expected_partners))
+        followers_id = [f.id for f in stored.mapped(
+            'message_follower_ids.partner_id')]
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertNotIn(self.other_partner_b.id, followers_id)


### PR DESCRIPTION
(previously connector_job_subscribe in connector repository and renamed queue_job_subscribe in queue repository)
see discussion on https://github.com/OCA/connector/pull/250
Travis will probably fail as long as queue_job subscribe is not merged