### PR TITLE
[FIX] queue_job: Complete migration script

### DIFF
--- a/queue_job/migrations/10.0.1.0.0/end-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/end-migration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Tecnativa - Pedro M. Baeza
+# Copyright 2017-2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, SUPERUSER_ID
@@ -12,13 +12,18 @@ def migrate(cr, version):
     if not version:
         return
     env = api.Environment(cr, SUPERUSER_ID, {})
-    jobs = env['queue.job'].search([])
-    for job in jobs:
-        if job.model_name not in env:
+    QueueJob = env['queue.job']
+    groups = QueueJob.read_groups(
+        [], ['model_name', 'method_name'], ['model_name', 'method_name'],
+        lazy=False,
+    )
+    for group in groups:
+        if group['model_name'] not in env:
             continue
-        model = env[job.model_name]
-        method = getattr(model, job.method_name, False)
-        if method:
-            job.channel_method_name = '<%s>.%s' % (
+        model = env[group['model_name']]
+        method = getattr(model, group['method_name'], False)
+        QueueJob.search(group['__domain']).write({
+            'channel_method_name': '<%s>.%s' % (
                 method.im_class._name, method.__name__,
-            )
+            ),
+        })

--- a/queue_job/migrations/10.0.1.0.0/end-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/end-migration.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Now that everything has been loaded, compute the value of
+    channel_method_name.
+    """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    jobs = env['queue.job'].search([])
+    for job in jobs:
+        if job.model_name not in env:
+            continue
+        model = env[job.model_name]
+        method = getattr(model, job.method_name, False)
+        if method:
+            job.channel_method_name = '<%s>.%s' % (
+                method.im_class._name, method.__name__,
+            )

--- a/queue_job/migrations/10.0.1.0.0/pre-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/pre-migration.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - Vicent Cubells
+# Copyright 2017-2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
 
 
 def migrate(cr, version):
@@ -25,5 +28,11 @@ def migrate(cr, version):
                  'queue_job.group_queue_job_manager',)
             ],
         )
+        # Pre-create column for avoiding the computation over non loaded models
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        openupgrade.add_fields(env, [
+            ('channel_method_name', 'queue.job', 'queue_job', 'char', False,
+             'queue_job'),
+        ])
     except ImportError:
-        pass
+        raise Exception("You need openupgradelib for performing the migration")


### PR DESCRIPTION
I don't want to let the migration script half-finished with a case I have found in one DB, but please don't be so picky.

Rationale: As there's a new computed field called `channel_method_name`, if the computation is done on module upgrade, maybe some models are not loaded yet, so we pre-create the column for avoiding this calculation and make it manually at the end of the process. We redo the computing code relaxing the constraints for avoiding also errors on missing models or methods.

@Tecnativa