### PR TITLE
[8.0][IMP]: 8.0 backports from 10.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
 
 env:
   global:
-  - VERSION="10.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+  - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
   # This line contains the encrypted transifex password
   # To encrypt transifex password, install travis ruby utils with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/OCA/queue.svg?branch=10.0)](https://travis-ci.org/OCA/queue)
-[![codecov](https://codecov.io/gh/OCA/queue/branch/10.0/graph/badge.svg)](https://codecov.io/gh/OCA/queue)
+[![Build Status](https://travis-ci.org/OCA/queue.svg?branch=8.0)](https://travis-ci.org/OCA/queue)
+[![codecov](https://codecov.io/gh/OCA/queue/branch/8.0/graph/badge.svg)](https://codecov.io/gh/OCA/queue)
 
 
 Odoo Queue Modules
@@ -17,13 +17,13 @@ Available addons
 ----------------
 addon | version | summary
 --- | --- | ---
-[queue_job](queue_job/) | 10.0.1.0.0 | Job Queue
-[queue_job_subscribe](queue_job_subscribe/) | 10.0.1.0.0 | Control which users are subscribed to queue job notifications
-[test_queue_job](test_queue_job/) | 10.0.1.0.0 | Queue Job Tests
+[queue_job](queue_job/) | 8.0.1.0.0 | Job Queue
+[queue_job_subscribe](queue_job_subscribe/) | 8.0.1.0.0 | Control which users are subscribed to queue job notifications
+[test_queue_job](test_queue_job/) | 8.0.1.0.0 | Queue Job Tests
 
 [//]: # (end addons)
 
 Translation Status
 ------------------
-[![Transifex Status](https://www.transifex.com/projects/p/OCA-queue-10-0/chart/image_png)](https://www.transifex.com/projects/p/OCA-queue-10-0)
+[![Transifex Status](https://www.transifex.com/projects/p/OCA-queue-8-0/chart/image_png)](https://www.transifex.com/projects/p/OCA-queue-8-0)
 

--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -119,7 +119,7 @@ To use this module, you need to:
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/230/10.0
+   :target: https://runbot.odoo-community.org/runbot/230/8.0
 
 Known issues / Roadmap
 ======================

--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -16,8 +16,8 @@ Example:
 
 .. code-block:: python
 
-  from odoo import models, fields, api
-  from odoo.addons.queue_job.job import job
+  from openerp import models, fields, api
+  from openerp.addons.queue_job.job import job
 
   class MyModel(models.Model):
      _name = 'my.model'
@@ -105,7 +105,7 @@ Configuration
   start immediately and in parallel.
 
 * Tip: to enable debug logging for the queue job, use
-  ``--log-handler=odoo.addons.queue_job:DEBUG``
+  ``--log-handler=openerp.addons.queue_job:DEBUG``
 
 .. [1] It works with the threaded Odoo server too, although this way
        of running Odoo is obviously not for production purposes.

--- a/queue_job/__openerp__.py
+++ b/queue_job/__openerp__.py
@@ -3,7 +3,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '10.0.1.0.0',
+ 'version': '8.0.1.0.0',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue/queue_job',
  'license': 'AGPL-3',

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -9,9 +9,9 @@ from cStringIO import StringIO
 
 from psycopg2 import OperationalError
 
-import odoo
-from odoo import _, http, tools
-from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
+import openerp
+from openerp import _, http, tools
+from openerp.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 from ..job import Job, ENQUEUED
 from ..exception import (NoSuchJobError,
@@ -68,7 +68,7 @@ class RunJobController(http.Controller):
     @http.route('/queue_job/runjob', type='http', auth='none')
     def runjob(self, db, job_uuid, **kw):
         http.request.session.db = db
-        env = http.request.env(user=odoo.SUPERUSER_ID)
+        env = http.request.env(user=openerp.SUPERUSER_ID)
 
         def retry_postpone(job, message, seconds=None):
             job.postpone(result=message, seconds=seconds)
@@ -113,8 +113,8 @@ class RunJobController(http.Controller):
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())
             job.env.clear()
-            with odoo.api.Environment.manage():
-                with odoo.registry(job.env.cr.dbname).cursor() as new_cr:
+            with openerp.api.Environment.manage():
+                with openerp.registry(job.env.cr.dbname).cursor() as new_cr:
                     job.env = job.env(cr=new_cr)
                     job.set_failed(exc_info=buff.getvalue())
                     job.store()

--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<openerp>
     <data noupdate="1">
 
         <!-- Queue-job-related subtypes for messaging / Chatter -->
@@ -31,4 +31,4 @@
         </record>
 
     </data>
-</odoo>
+</openerp>

--- a/queue_job/exception.py
+++ b/queue_job/exception.py
@@ -28,7 +28,7 @@ class RetryableJobError(JobError):
 
     The job will be retried after the given number of seconds.  If seconds is
     empty, it will be retried according to the ``retry_pattern`` of the job or
-    by :const:`odoo.addons.queue_job.job.RETRY_INTERVAL` if nothing is defined.
+    by :const:`openerp.addons.queue_job.job.RETRY_INTERVAL` if nothing is defined.
 
     If ``ignore_retry`` is True, the retry counter will not be increased.
     """

--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -6,8 +6,9 @@ import json
 from datetime import datetime, date
 
 import dateutil
+import dateutil.parser
 
-from odoo import fields, models
+from openerp import fields, models
 
 
 class JobSerialized(fields.Field):
@@ -25,6 +26,19 @@ class JobSerialized(fields.Field):
             return value
         else:
             return json.loads(value, cls=JobDecoder, env=record.env)
+
+
+def convert_to_column(value):
+    return json.dumps(value, cls=JobEncoder)
+
+
+def convert_to_cache(value, env):
+    # cache format: dict
+    value = value or {}
+    if isinstance(value, dict):
+        return value
+    else:
+        return json.loads(value, cls=JobDecoder, env=env)
 
 
 class JobEncoder(json.JSONEncoder):

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -9,7 +9,8 @@ import uuid
 import sys
 from datetime import datetime, timedelta
 
-import odoo
+import openerp
+from .fields import convert_to_cache
 
 from .exception import (NoSuchJobError,
                         FailedJobError,
@@ -43,7 +44,7 @@ class DelayableRecordset(object):
         delayable.method(args, kwargs)
 
     ``method`` must be a method of the recordset's Model, decorated with
-    :func:`~odoo.addons.queue_job.job.job`.
+    :func:`~openerp.addons.queue_job.job.job`.
 
     The method call will be processed asynchronously in the job queue, with
     the passed arguments.
@@ -70,7 +71,7 @@ class DelayableRecordset(object):
         if not getattr(recordset_method, 'delayable', None):
             raise AttributeError(
                 'method %s on %s is not allowed to be delayed, '
-                'it should be decorated with odoo.addons.queue_job.job.job' %
+                'it should be decorated with openerp.addons.queue_job.job.job' %
                 (name, self.recordset)
             )
 
@@ -195,15 +196,16 @@ class Job(object):
             raise NoSuchJobError(
                 'Job %s does no longer exist in the storage.' % job_uuid)
 
-        args = stored.args
-        kwargs = stored.kwargs
+        args = convert_to_cache(stored.args, env)
+        kwargs = convert_to_cache(stored.kwargs, env)
+
         method_name = stored.method_name
 
         model = env[stored.model_name]
         recordset = model.browse(stored.record_ids)
         method = getattr(recordset, method_name)
 
-        dt_from_string = odoo.fields.Datetime.from_string
+        dt_from_string = openerp.fields.Datetime.from_string
         eta = None
         if stored.eta:
             eta = dt_from_string(stored.eta)
@@ -291,7 +293,7 @@ class Job(object):
             is computed from the function doc or name
         :param channel: The complete channel name to use to process the job.
         :param env: Odoo Environment
-        :type env: :class:`odoo.api.Environment`
+        :type env: :class:`openerp.api.Environment`
         """
         if args is None:
             args = ()
@@ -304,7 +306,7 @@ class Job(object):
         assert isinstance(kwargs, dict), "%s: kwargs are not a dict" % kwargs
 
         if (not inspect.ismethod(func) or
-                not isinstance(func.im_class, odoo.models.MetaModel)):
+                not isinstance(func.im_class, openerp.models.MetaModel)):
             raise TypeError("Job accepts only methods of Models")
 
         recordset = func.im_self
@@ -353,7 +355,7 @@ class Job(object):
             company_id = company_model._company_default_get(
                 object='queue.job',
                 field='company_id'
-            ).id
+            )
         self.company_id = company_id
         self._eta = None
         self.eta = eta
@@ -401,7 +403,7 @@ class Job(object):
                 'eta': False,
                 }
 
-        dt_to_string = odoo.fields.Datetime.to_string
+        dt_to_string = openerp.fields.Datetime.to_string
         if self.date_enqueued:
             vals['date_enqueued'] = dt_to_string(self.date_enqueued)
         if self.date_started:
@@ -546,7 +548,7 @@ class Job(object):
 
 def _is_model_method(func):
     return (inspect.ismethod(func) and
-            isinstance(func.im_class, odoo.models.MetaModel))
+            isinstance(func.im_class, openerp.models.MetaModel))
 
 
 def job(func=None, default_channel='root', retry_pattern=None):

--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -8,8 +8,8 @@ import os
 from threading import Thread
 import time
 
-from odoo.service import server
-from odoo.tools import config
+from openerp.service import server
+from openerp.tools import config
 
 from .runner import QueueJobRunner
 

--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -536,7 +536,7 @@ class Channel(object):
         :param now: the current datetime in seconds
 
         :return: iterator of
-                 :class:`odoo.addons.queue_job.jobrunner.ChannelJob`
+                 :class:`openerp.addons.queue_job.jobrunner.ChannelJob`
         """
         # enqueue jobs of children channels
         for child in self.children.values():

--- a/queue_job/security/security.xml
+++ b/queue_job/security/security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<openerp>
     <data>
 
     <record model="ir.module.category" id="module_category_queue_job">
@@ -25,5 +25,5 @@
     </record>
 
     </data>
-</odoo>
+</openerp>
 

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -5,8 +5,8 @@
 from datetime import datetime, date
 import json
 
-from odoo.tests import common
-from odoo.addons.queue_job.fields import JobEncoder, JobDecoder
+from openerp.tests import common
+from openerp.addons.queue_job.fields import JobEncoder, JobDecoder
 
 
 class TestJson(common.TransactionCase):

--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import doctest
-from odoo.addons.queue_job.jobrunner import channels
+from openerp.addons.queue_job.jobrunner import channels
 
 
 def load_tests(loader, tests, ignore):

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import doctest
-from odoo.addons.queue_job.jobrunner import runner
+from openerp.addons.queue_job.jobrunner import runner
 
 
 def load_tests(loader, tests, ignore):

--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<openerp><data>
 
     <record id="view_queue_job_form" model="ir.ui.view">
         <field name="name">queue.job.form</field>
@@ -294,4 +294,4 @@
         sequence="14"
         parent="menu_queue"/>
 
-</odoo>
+</data></openerp>

--- a/queue_job_subscribe/README.rst
+++ b/queue_job_subscribe/README.rst
@@ -22,7 +22,7 @@ If not checked, the user does not become follower of failed jobs.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/230/10.0
+   :target: https://runbot.odoo-community.org/runbot/230/8.0
 
 
 Bug Tracker

--- a/queue_job_subscribe/__openerp__.py
+++ b/queue_job_subscribe/__openerp__.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Cédric Pigeon
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Queue Job Subscribe',
- 'version': '10.0.1.0.0',
+ 'version': '8.0.1.0.0',
  'author': 'Acsone SA/NV,'
            'Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue_job',

--- a/queue_job_subscribe/views/res_users_view.xml
+++ b/queue_job_subscribe/views/res_users_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<openerp><data>
 
-<odoo>
     <record id="view_user_connector_form" model="ir.ui.view">
         <field name="name">res.user.connector.form</field>
         <field name="model">res.users</field>
@@ -15,4 +15,5 @@
             </xpath>
         </field>
     </record>
-</odoo>
+
+</data></openerp>

--- a/test_queue_job/__openerp__.py
+++ b/test_queue_job/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 {'name': 'Queue Job Tests',
- 'version': '10.0.1.0.0',
+ 'version': '8.0.1.0.0',
  'author': 'Camptocamp,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Generic Modules',

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -2,9 +2,9 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import api, fields, models
-from odoo.addons.queue_job.job import job, related_action
-from odoo.addons.queue_job.exception import RetryableJobError
+from openerp import api, fields, models
+from openerp.addons.queue_job.job import job, related_action
+from openerp.addons.queue_job.exception import RetryableJobError
 
 
 class QueueJob(models.Model):
@@ -33,6 +33,7 @@ class QueueJob(models.Model):
 class TestQueueJob(models.Model):
 
     _name = 'test.queue.job'
+    _inherit = 'base'
     _description = "Test model for queue.job"
 
     name = fields.Char()
@@ -77,6 +78,7 @@ class TestQueueJob(models.Model):
 class TestQueueChannel(models.Model):
 
     _name = 'test.queue.channel'
+    _inherit = 'base'
     _description = "Test model for queue.channel"
 
     @job
@@ -95,6 +97,7 @@ class TestQueueChannel(models.Model):
 class TestRelatedAction(models.Model):
 
     _name = 'test.related.action'
+    _inherit = 'base'
     _description = "Test model for related actions"
 
     @job

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -33,7 +33,6 @@ class QueueJob(models.Model):
 class TestQueueJob(models.Model):
 
     _name = 'test.queue.job'
-    _inherit = 'base'
     _description = "Test model for queue.job"
 
     name = fields.Char()
@@ -78,7 +77,6 @@ class TestQueueJob(models.Model):
 class TestQueueChannel(models.Model):
 
     _name = 'test.queue.channel'
-    _inherit = 'base'
     _description = "Test model for queue.channel"
 
     @job
@@ -97,7 +95,6 @@ class TestQueueChannel(models.Model):
 class TestRelatedAction(models.Model):
 
     _name = 'test.related.action'
-    _inherit = 'base'
     _description = "Test model for related actions"
 
     @job

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -5,15 +5,15 @@
 from datetime import datetime, timedelta
 import mock
 
-from odoo import SUPERUSER_ID
-import odoo.tests.common as common
+from openerp import SUPERUSER_ID
+import openerp.tests.common as common
 
-from odoo.addons.queue_job.exception import (
+from openerp.addons.queue_job.exception import (
     FailedJobError,
     NoSuchJobError,
     RetryableJobError,
 )
-from odoo.addons.queue_job.job import (
+from openerp.addons.queue_job.job import (
     Job,
     RETRY_INTERVAL,
     PENDING,
@@ -48,7 +48,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_eta_integer(self):
         """ When an `eta` is an integer, it adds n seconds up to now """
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a = Job(self.method, eta=60)
@@ -56,7 +56,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_eta_timedelta(self):
         """ When an `eta` is a timedelta, it adds it up to now """
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             delta = timedelta(hours=3)
@@ -123,7 +123,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_set_enqueued(self):
         job_a = Job(self.method)
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_enqueued()
@@ -135,7 +135,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_set_started(self):
         job_a = Job(self.method)
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_started()
@@ -146,7 +146,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_set_done(self):
         job_a = Job(self.method)
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_done(result='test')
@@ -165,7 +165,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
 
     def test_postpone(self):
         job_a = Job(self.method)
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.postpone(result='test', seconds=60)
@@ -318,7 +318,7 @@ class TestJobs(common.TransactionCase):
 
     def test_retry_pattern(self):
         """ When we specify a retry pattern, the eta must follow it"""
-        datetime_path = 'odoo.addons.queue_job.job.datetime'
+        datetime_path = 'openerp.addons.queue_job.job.datetime'
         method = self.env['test.queue.job'].job_with_retry_pattern
         with mock.patch(datetime_path, autospec=True) as mock_datetime:
             mock_datetime.now.return_value = datetime(

--- a/test_queue_job/tests/test_job_channels.py
+++ b/test_queue_job/tests/test_job_channels.py
@@ -2,9 +2,9 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import exceptions
-import odoo.tests.common as common
-from odoo.addons.queue_job.job import Job, job
+from openerp import exceptions
+import openerp.tests.common as common
+from openerp.addons.queue_job.job import Job, job
 
 
 class TestJobChannels(common.TransactionCase):

--- a/test_queue_job/tests/test_related_actions.py
+++ b/test_queue_job/tests/test_related_actions.py
@@ -2,8 +2,8 @@
 # Copyright 2014-2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-import odoo.tests.common as common
-from odoo.addons.queue_job.job import Job
+import openerp.tests.common as common
+from openerp.addons.queue_job.job import Job
 
 
 class TestRelatedAction(common.TransactionCase):


### PR DESCRIPTION
Requied only patch original Odoo to support 'base' model

After https://github.com/odoo/odoo/blob/8.0/openerp/models.py#L592
```
        # all models except 'base' implicitly inherit from 'base'
        if name != 'base':
            parents = list(parents) + ['base']

```

And after https://github.com/odoo/odoo/blob/8.0/openerp/addons/base/ir/ir_model.py#L64

```
#
# IMPORTANT: this must be the first model declared in the module
#
class Base(models.AbstractModel):
    """ The base model, which is implicitly inherited by all models. """
    _name = 'base'
```