### PR TITLE
[IMP] avoid base_sparse_field --load

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -76,7 +76,7 @@ Configuration
 
   - if ``xmlrpc_port`` is not set: ``ODOO_QUEUE_JOB_PORT=8069``
 
- * Start Odoo with ``--load=web,base_sparse_field,queue_job``
+ * Start Odoo with ``--load=web,queue_job``
    and ``--workers`` greater than 1. [1]_
 
 

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -6,6 +6,11 @@ import logging
 from datetime import datetime, timedelta
 
 from odoo import models, fields, api, exceptions, _
+# Import `Serialized` field straight to avoid:
+# * remember to use --load=base_sparse_field...
+# * make pytest happy
+# * make everybody happy :
+from odoo.addons.base_sparse_field.models.fields import Serialized
 
 from ..job import STATES, DONE, PENDING, Job
 from ..fields import JobSerialized
@@ -41,7 +46,7 @@ class QueueJob(models.Model):
 
     model_name = fields.Char(string='Model', readonly=True)
     method_name = fields.Char(readonly=True)
-    record_ids = fields.Serialized(readonly=True)
+    record_ids = Serialized(readonly=True)
     args = JobSerialized(readonly=True)
     kwargs = JobSerialized(readonly=True)
     func_string = fields.Char(string='Task', compute='_compute_func_string',


### PR DESCRIPTION
`base_sparse_field` patches odoo fields
in order to be able to use `fields.Serialized`.

To "pay" this shortcut you have to load it at server load
which makes harder to test it with external tools (ie: pytest)
and disorient first users as they always miss this step.

Now we load the field straight from the module: easy, neat, works.