### PR TITLE
[FIX] Get attributes on the class instead of recordsets

### DIFF
--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -16,9 +16,11 @@ class Base(models.AbstractModel):
     def _register_hook(self):
         """ register marked jobs """
         super(Base, self)._register_hook()
-        job_methods = [method for __, method
-                       in inspect.getmembers(self, predicate=inspect.ismethod)
-                       if getattr(method, 'delayable', None)]
+        job_methods = [
+            method for __, method
+            in inspect.getmembers(self.__class__, predicate=inspect.ismethod)
+            if getattr(method, 'delayable', None)
+        ]
         for job_method in job_methods:
             self.env['queue.job.function']._register_job(job_method)
         # add_to_job_registry(job_methods)


### PR DESCRIPTION
Even if the recordset is empty, this is still an instance of the class, so the @property methods are called. As this type of method is usually run on a single record, they need self.ensure_one(), which crashes when evaluated on a recordset, preventing the server to start when queue_job is installed.

Getting the attributes on the class itself instead of using an empty recordset avoids evaluating property methods.