### PR TITLE
queue_job_cron: do not require read access to ir.cron

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -41,7 +41,7 @@ class IrCron(models.Model):
 
     @api.model
     def _callback(self, model_name, method_name, args, job_id):
-        cron = self.env['ir.cron'].browse(job_id)
+        cron = self.env['ir.cron'].sudo().browse(job_id)
         if cron.run_as_queue_job:
             return self.with_delay(
                 priority=cron.priority,


### PR DESCRIPTION
fixes #48 