### PR TITLE
[10.0] Add identity key on job to allow limiting redundant execution

### DIFF
--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -26,7 +26,7 @@ class Base(models.AbstractModel):
     @api.multi
     def with_delay(self, priority=None, eta=None,
                    max_retries=None, description=None,
-                   channel=None):
+                   channel=None, identity_key=None):
         """ Return a ``DelayableRecordset``
 
         The returned instance allow to enqueue any method of the recordset's
@@ -52,6 +52,9 @@ class Base(models.AbstractModel):
         :param channel: the complete name of the channel to use to process
                         the function. If specified it overrides the one
                         defined on the function
+        :param identity_key: key uniquely identifying the job, if specified
+                             and a job with the same key has not yet been run,
+                             the new job will not be added.
         :return: instance of a DelayableRecordset
         :rtype: :class:`odoo.addons.queue_job.job.DelayableRecordset`
 
@@ -60,4 +63,5 @@ class Base(models.AbstractModel):
                                   eta=eta,
                                   max_retries=max_retries,
                                   description=description,
-                                  channel=channel)
+                                  channel=channel,
+                                  identity_key=identity_key)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -83,6 +83,21 @@ class QueueJob(models.Model):
                           store=True,
                           index=True)
 
+    identity_key = fields.Char()
+
+    @api.model_cr
+    def init(self):
+        self._cr.execute(
+            'SELECT indexname FROM pg_indexes WHERE indexname = %s ',
+            ('queue_job_identity_key_state_partial_index',)
+        )
+        if not self._cr.fetchone():
+            self._cr.execute(
+                "CREATE INDEX queue_job_identity_key_state_partial_index "
+                "ON queue_job (identity_key) WHERE state in ('pending', "
+                "'enqueued') AND identity_key IS NOT NULL;"
+            )
+
     @api.multi
     def _inverse_channel(self):
         self.filtered(lambda a: not a.channel)._compute_channel()

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -2,6 +2,8 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import hashlib
+
 from datetime import datetime, timedelta
 import mock
 
@@ -21,6 +23,7 @@ from odoo.addons.queue_job.job import (
     STARTED,
     DONE,
     FAILED,
+    identity_exact,
 )
 
 
@@ -295,7 +298,7 @@ class TestJobsOnTestingMethod(common.TransactionCase):
             (('a',), {'k': 1})
         )
 
-    def test_job_identity_key(self):
+    def test_job_identity_key_str(self):
         id_key = 'e294e8444453b09d59bdb6efbfec1323'
         test_job_1 = Job(self.method,
                          priority=15,
@@ -305,6 +308,25 @@ class TestJobsOnTestingMethod(common.TransactionCase):
         test_job_1.store()
         job1 = Job.load(self.env, test_job_1.uuid)
         self.assertEqual(job1.identity_key, id_key)
+
+    def test_job_identity_key_func_exact(self):
+        hasher = hashlib.sha1()
+        hasher.update('test.queue.job')
+        hasher.update('testing_method')
+        hasher.update(str(sorted([])))
+        hasher.update(unicode((1, 'foo')))
+        hasher.update(unicode(sorted({'bar': 'baz'}.items())))
+        expected_key = hasher.hexdigest()
+
+        test_job_1 = Job(self.method,
+                         args=[1, 'foo'],
+                         kwargs={'bar': 'baz'},
+                         identity_key=identity_exact)
+        self.assertEqual(test_job_1.identity_key, expected_key)
+        test_job_1.store()
+
+        job1 = Job.load(self.env, test_job_1.uuid)
+        self.assertEqual(job1.identity_key, expected_key)
 
 
 class TestJobs(common.TransactionCase):
@@ -391,14 +413,15 @@ class TestJobs(common.TransactionCase):
         self.assertEquals(job_instance.method_name, 'mapped')
         self.assertEquals(['test1', 'test2'], job_instance.perform())
 
-    def test_job_no_duplicate(self):
+    def test_job_identity_key_no_duplicate(self):
         """ If a job with same identity key in queue do not add a new one """
         id_key = 'e294e8444453b09d59bdb6efbfec1323'
         rec1 = self.env['test.queue.job'].create({'name': 'test1'})
         job_1 = rec1.with_delay(identity_key=id_key).mapped('name')
+
         self.assertTrue(job_1)
         job_2 = rec1.with_delay(identity_key=id_key).mapped('name')
-        self.assertFalse(job_2)
+        self.assertEqual(job_2.uuid, job_1.uuid)
 
     def test_job_with_mutable_arguments(self):
         """ Job with mutable arguments do not mutate on perform() """


### PR DESCRIPTION
This to implement a solution to the issue raised on issue #57 
