### PR TITLE
Fix auto registration of job methods and channels

### DIFF
--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -18,11 +18,11 @@ class Base(models.AbstractModel):
         super(Base, self)._register_hook()
         job_methods = [
             method for __, method
-            in inspect.getmembers(self.__class__, predicate=inspect.ismethod)
+            in inspect.getmembers(self.__class__, predicate=inspect.isfunction)
             if getattr(method, 'delayable', None)
         ]
         for job_method in job_methods:
-            self.env['queue.job.function']._register_job(job_method)
+            self.env['queue.job.function']._register_job(self, job_method)
 
     @api.multi
     def with_delay(self, priority=None, eta=None,

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -18,8 +18,8 @@ from ..fields import JobSerialized
 _logger = logging.getLogger(__name__)
 
 
-def channel_func_name(method):
-    return '<%s>.%s' % (method.__self__._name, method.__name__)
+def channel_func_name(model, method):
+    return '<%s>.%s' % (model._name, method.__name__)
 
 
 class QueueJob(models.Model):
@@ -104,7 +104,7 @@ class QueueJob(models.Model):
         for record in self:
             model = self.env[record.model_name]
             method = getattr(model, record.method_name)
-            channel_method_name = channel_func_name(method)
+            channel_method_name = channel_func_name(model, method)
             func_model = self.env['queue.job.function']
             function = func_model.search([('name', '=', channel_method_name)])
             record.channel_method_name = channel_method_name
@@ -355,8 +355,8 @@ class JobFunction(models.Model):
         return channel
 
     @api.model
-    def _register_job(self, job_method):
-        func_name = channel_func_name(job_method)
+    def _register_job(self, model, job_method):
+        func_name = channel_func_name(model, job_method)
         if not self.search_count([('name', '=', func_name)]):
             channel = self._find_or_create_channel(job_method.default_channel)
             self.create({'name': func_name, 'channel_id': channel.id})

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -91,6 +91,16 @@ class TestQueueChannel(models.Model):
     def job_sub_channel(self):
         return
 
+    @property
+    def dummy_property(self):
+        """ Return foo
+
+        Only there to check that properties are compatible
+        with the automatic registration of job methods
+        and their default channels.
+        """
+        return 'foo'
+
 
 class TestRelatedAction(models.Model):
 

--- a/test_queue_job/tests/test_job_channels.py
+++ b/test_queue_job/tests/test_job_channels.py
@@ -41,9 +41,15 @@ class TestJobChannels(common.TransactionCase):
         self.env['queue.job.channel'].search([('name', '!=', 'root')]).unlink()
 
         method_a = self.env['test.queue.channel'].job_a
-        self.env['queue.job.function']._register_job(method_a)
+        self.env['queue.job.function']._register_job(
+            self.env['test.queue.channel'],
+            method_a
+        )
         method_b = self.env['test.queue.channel'].job_b
-        self.env['queue.job.function']._register_job(method_b)
+        self.env['queue.job.function']._register_job(
+            self.env['test.queue.channel'],
+            method_b
+        )
 
         path_a = '<test.queue.channel>.job_a'
         path_b = '<test.queue.channel>.job_b'
@@ -59,7 +65,10 @@ class TestJobChannels(common.TransactionCase):
         self.env['queue.job.channel'].search([('name', '!=', 'root')]).unlink()
 
         method = self.env['test.queue.channel'].job_a
-        self.env['queue.job.function']._register_job(method)
+        self.env['queue.job.function']._register_job(
+            self.env['test.queue.channel'],
+            method
+        )
         path_a = '<%s>.%s' % (method.__self__.__class__._name, method.__name__)
         job_func = self.function_model.search([('name', '=', path_a)])
         self.assertEquals(job_func.channel, 'root')
@@ -92,7 +101,10 @@ class TestJobChannels(common.TransactionCase):
         self.env['queue.job.channel'].search([('name', '!=', 'root')]).unlink()
 
         method = self.env['test.queue.channel'].job_sub_channel
-        self.env['queue.job.function']._register_job(method)
+        self.env['queue.job.function']._register_job(
+            self.env['test.queue.channel'],
+            method
+        )
         self.assertEquals(method.default_channel, 'root.sub.subsub')
 
         path_a = '<%s>.%s' % (method.__self__.__class__._name, method.__name__)


### PR DESCRIPTION
The automatic registration of job methods and their defaut channel
has been a bit chaotic. The initial version for the new Odoo API could
crashing as soon as a method was decorated by @property. There is
such a property in the code code, the method '_cache'.

The problem of the crash was that, the introspection basically uses a
'getattr' on every attribute of the instance. The '_cache' method
could then be called on an empty recordset, which is not supported by
'_cache'.

A first correction (49d8f37) was to naively skip the '_cache' method
from the introspection.

In any case, it is wrong to access the property of an instance only to
instrospect its members.  That's why the correction 4ebb2452 changed the
inspection from the instance to the class.

Properties are no longer accessed, however this correction was not
correct for Python 3. When members of the class are introspected, they
are neither bound neither unbound methods. they are mere functions.

The change here is to lookup for functions. _register_job must now takes
the model as input argument, because there is no way to get the name of
the model from the function.

Closes #64
Follows #50
