### PR TITLE
Update README.rst - remove web_kanban

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -87,7 +87,7 @@ Configuration
   [options]
   (...)
   workers = 4
-  server_wide_modules = web,web_kanban,queue_job
+  server_wide_modules = web,queue_job
 
   (...)
   [queue_job]


### PR DESCRIPTION
web_kanban exists no more in Odoo 11.0