### PR TITLE
Change number of workers in configuration example

### DIFF
--- a/queue_job/readme/CONFIGURE.rst
+++ b/queue_job/readme/CONFIGURE.rst
@@ -17,12 +17,12 @@
 
   [options]
   (...)
-  workers = 4
+  workers = 6
   server_wide_modules = web,queue_job
 
   (...)
   [queue_job]
-  channels = root:4
+  channels = root:2
 
 * Confirm the runner is starting correctly by checking the odoo log file:
 


### PR DESCRIPTION
The basic configuration shown will block the HTTP workers when 4 jobs
are processed concurrently.

The documentation needs love, this is a tiny step in that direction.