### PR TITLE
[draft] 11.0 UI notifications for jobs

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -8,7 +8,8 @@
  'license': 'AGPL-3',
  'category': 'Generic Modules',
  'depends': ['mail',
-             'base_sparse_field'
+             'bus',
+             'base_sparse_field',
              ],
  'external_dependencies': {'python': ['requests'
                                       ],
@@ -16,6 +17,7 @@
  'data': ['security/security.xml',
           'security/ir.model.access.csv',
           'views/queue_job_views.xml',
+          'views/queue_job.xml',
           'data/queue_data.xml',
           ],
  'installable': True,

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -219,6 +219,44 @@ class QueueJob(models.Model):
         jobs.unlink()
         return True
 
+    QUEUE_JOB_NOTIFY_TITLE = _('Background processing')
+
+    # TODO: factorize
+    # TODO: accept message as function taking job as arg
+    # TODO: group similar notifications in one notif?
+    def notify_job_created(self, message=None):
+        self.ensure_one()
+        payload = {
+            'title': self.QUEUE_JOB_NOTIFY_TITLE,
+            'message': message or _('<b>%s</b> is created.') % (self.name,),
+            'sticky': False,
+        }
+        job_user_id = self.user_id.id
+        channel = 'notify_queue_job_created_%s' % (job_user_id,)
+        self.env['bus.bus'].sendone(channel, payload)
+
+    def notify_job_done(self, message=None):
+        self.ensure_one()
+        payload = {
+            'title': self.QUEUE_JOB_NOTIFY_TITLE,
+            'message': message or _('<b>%s</b> is done.') % (self.name,),
+            'sticky': False,
+        }
+        job_user_id = self.user_id.id
+        channel = 'notify_queue_job_done_%s' % (job_user_id,)
+        self.env['bus.bus'].sendone(channel, payload)
+
+    def notify_job_failed(self, message=None):
+        self.ensure_one()
+        payload = {
+            'title': self.QUEUE_JOB_NOTIFY_TITLE,
+            'message': message or _('<b>%s</b> is failed.') % (self.name,),
+            'sticky': False,
+        }
+        job_user_id = self.user_id.id
+        channel = 'notify_queue_job_failed_%s' % (job_user_id,)
+        self.env['bus.bus'].sendone(channel, payload)
+
 
 class RequeueJob(models.TransientModel):
     _name = 'queue.requeue.job'

--- a/queue_job/static/src/js/web_client.js
+++ b/queue_job/static/src/js/web_client.js
@@ -1,0 +1,51 @@
+odoo.define('queue_job.WebClient', function(require) {
+"use strict";
+
+var WebClient = require('web.WebClient');
+var base_bus = require('bus.bus');
+var session = require('web.session');
+
+WebClient.include({
+    show_application: function() {
+        var result = this._super();
+        this.start_polling();
+        return result;
+    },
+
+    start_polling: function() {
+        this.channel_created = 'notify_queue_job_created_' + session.uid;
+        this.channel_done = 'notify_queue_job_done_' + session.uid;
+        this.channel_failed = 'notify_queue_job_failed_' + session.uid;
+        base_bus.bus.add_channel(this.channel_created);
+        base_bus.bus.add_channel(this.channel_done);
+        base_bus.bus.add_channel(this.channel_failed);
+        base_bus.bus.on('notification', this, this.bus_notification);
+        base_bus.bus.start_polling();
+    },
+    bus_notification: function(notifications) {
+        var self = this;
+        _.each(notifications, function (notification) {
+            var channel = notification[0];
+            var message = notification[1];
+            if (channel === self.channel_created) {
+                self.on_message_info(message);
+            } else if (channel === self.channel_done) {
+                self.on_message_info(message);
+            } else if (channel === self.channel_failed) {
+                self.on_message_failure(message);
+            }
+        });
+    },
+    on_message_failure: function(message){
+        if(this.notification_manager) {
+            this.notification_manager.do_warn(message.title, message.message, message.sticky);
+        }
+    },
+    on_message_info: function(message){
+        if(this.notification_manager) {
+            this.notification_manager.do_notify(message.title, message.message, message.sticky);
+        }
+    }
+});
+
+});

--- a/queue_job/static/src/js/web_client.js
+++ b/queue_job/static/src/js/web_client.js
@@ -13,12 +13,10 @@ WebClient.include({
     },
 
     start_polling: function() {
-        this.channel_created = 'notify_queue_job_created_' + session.uid;
-        this.channel_done = 'notify_queue_job_done_' + session.uid;
-        this.channel_failed = 'notify_queue_job_failed_' + session.uid;
-        base_bus.bus.add_channel(this.channel_created);
-        base_bus.bus.add_channel(this.channel_done);
-        base_bus.bus.add_channel(this.channel_failed);
+        this.channel_notify = 'notify_queue_job_notify_' + session.uid;
+        this.channel_warn = 'notify_queue_job_warn_' + session.uid;
+        base_bus.bus.add_channel(this.channel_notify);
+        base_bus.bus.add_channel(this.channel_warn);
         base_bus.bus.on('notification', this, this.bus_notification);
         base_bus.bus.start_polling();
     },
@@ -27,23 +25,21 @@ WebClient.include({
         _.each(notifications, function (notification) {
             var channel = notification[0];
             var message = notification[1];
-            if (channel === self.channel_created) {
+            if (channel === self.channel_notify) {
                 self.on_message_info(message);
-            } else if (channel === self.channel_done) {
-                self.on_message_info(message);
-            } else if (channel === self.channel_failed) {
-                self.on_message_failure(message);
+            } else if (channel === self.channel_warn) {
+                self.on_message_warn(message);
             }
         });
-    },
-    on_message_failure: function(message){
-        if(this.notification_manager) {
-            this.notification_manager.do_warn(message.title, message.message, message.sticky);
-        }
     },
     on_message_info: function(message){
         if(this.notification_manager) {
             this.notification_manager.do_notify(message.title, message.message, message.sticky);
+        }
+    },
+    on_message_warn: function(message){
+        if(this.notification_manager) {
+            this.notification_manager.do_warn(message.title, message.message, message.sticky);
         }
     }
 });

--- a/queue_job/views/queue_job.xml
+++ b/queue_job/views/queue_job.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="assets_backend" name="queue_job assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/queue_job/static/src/js/web_client.js"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import _, api, fields, models
-from odoo.addons.queue_job.job import job, related_action
+from odoo.addons.queue_job.job import job, related_action, notify, notify_warn
 from odoo.addons.queue_job.exception import RetryableJobError
 
 
@@ -44,7 +44,9 @@ class TestQueueJob(models.Model):
 
     name = fields.Char()
 
-    @job(on_done='on_test_queue_job_testing_method_done')
+    @job(on_create=notify('Test job created'),
+         on_failure=notify_warn('Test job failed'),
+         on_done='on_test_queue_job_testing_method_done')
     @related_action(action='testing_related_method')
     @api.multi
     def testing_method(self, *args, **kwargs):

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -1,7 +1,7 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.addons.queue_job.job import job, related_action
 from odoo.addons.queue_job.exception import RetryableJobError
 
@@ -28,6 +28,14 @@ class QueueJob(models.Model):
             'url': kwargs['url'].format(subject=subject),
         }
 
+    @api.multi
+    def on_test_queue_job_testing_method_done(self):
+        self.ensure_one()
+        message = _('Job %s executed with args %s and kwargs %s') % (
+            self.uuid, self.args, self.kwargs
+        )
+        self.notify(message=message)
+
 
 class TestQueueJob(models.Model):
 
@@ -36,7 +44,7 @@ class TestQueueJob(models.Model):
 
     name = fields.Char()
 
-    @job
+    @job(on_done='on_test_queue_job_testing_method_done')
     @related_action(action='testing_related_method')
     @api.multi
     def testing_method(self, *args, **kwargs):


### PR DESCRIPTION
This is a draft of the API for job notifications. (https://twitter.com/guewenb/status/1000818392591462400)

There is code duplicated with [web_notify](https://github.com/OCA/web/tree/11.0/web_notify) which can be traded against a new dependency. 

https://github.com/OCA/web/tree/11.0/web_notifyhttps://github.com/OCA/web/tree/11.0/web_notify

The following events are triggered:

* A new job is enqueued
* Job started
* Job finished
* Job failed

You can also send a simple notification with: `notify` or `notify_warn`:

```python
            from odoo.addons.queue_job.job import job, notify

            @api.multi
            @job(on_done=notify('Partner exported'))
            def export_partner(self):
                # ...
```

For more advanced messages, you can also create methods on the `queue.job` model and refer to them with a string. This is also better for inheritance. From these hook methods, you can call `QueueJob.notify()` or  `QueueJob.notify_warn()`.

    Example usage:

```python

        class QueueJob(models.Model):
            _inherit = 'queue.job'

            @api.multi
            def on_export_partner_done(self):
                self.ensure_one()
                model = self.model_name
                partner = self.env[model].browse(self.record_ids)
                message = _('Partner %s exported') % partner.name
                self.notify(message=message)

        class ResPartner(models.Model):
            _inherit = 'res.partner'

            @api.multi
            @job(on_done='on_export_partner_done')
            def export_partner(self):
                # ...
```