### PR TITLE
[10.0] Add default related action to open related records

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -533,15 +533,20 @@ class Job(object):
             self.result = result
 
     def related_action(self):
-        if not hasattr(self.func, 'related_action'):
-            return None
-        if not self.func.related_action:
-            return None
-        if not isinstance(self.func.related_action, basestring):
+        record = self.db_record()
+        if hasattr(self.func, 'related_action'):
+            funcname = self.func.related_action
+            # decorator is set but empty: disable the default one
+            if not funcname:
+                return None
+        else:
+            funcname = record._default_related_action
+        if not isinstance(funcname, basestring):
             raise ValueError('related_action must be the name of the '
                              'method on queue.job as string')
-        action = getattr(self.db_record(), self.func.related_action)
-        return action(**self.func.kwargs)
+        action = getattr(record, funcname)
+        action_kwargs = getattr(self.func, 'kwargs', {})
+        return action(**action_kwargs)
 
 
 def _is_model_method(func):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -27,6 +27,7 @@ class QueueJob(models.Model):
     _order = 'date_created DESC, date_done DESC'
 
     _removal_interval = 30  # days
+    _default_related_action = 'related_action_open_record'
 
     uuid = fields.Char(string='UUID',
                        readonly=True,
@@ -126,7 +127,7 @@ class QueueJob(models.Model):
         job = Job.load(self.env, self.uuid)
         action = job.related_action()
         if action is None:
-            raise exceptions.Warning(_('No action available for this job'))
+            raise exceptions.UserError(_('No action available for this job'))
         return action
 
     @api.multi
@@ -215,6 +216,40 @@ class QueueJob(models.Model):
         )
         jobs.unlink()
         return True
+
+    @api.multi
+    def related_action_open_record(self):
+        """Open a form view with the record(s) of the job.
+
+        For instance, for a job on a ``product.product``, it will open a
+        ``product.product`` form view with the product record(s) concerned by
+        the job. If the job concerns more than one record, it opens them in a
+        list.
+
+        This is the default related action.
+
+        """
+        self.ensure_one()
+        model_name = self.model_name
+        records = self.env[model_name].browse(self.record_ids).exists()
+        if not records:
+            return None
+        action = {
+            'name': _('Related Record'),
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': records._name,
+        }
+        if len(records) == 1:
+            action['res_id'] = records.id
+        else:
+            action.update({
+                'name': _('Related Records'),
+                'view_mode': 'tree,form',
+                'domain': [('id', 'in', records.ids)],
+            })
+        return action
 
 
 class RequeueJob(models.TransientModel):

--- a/queue_job/readme/HISTORY.rst
+++ b/queue_job/readme/HISTORY.rst
@@ -1,0 +1,21 @@
+.. [ The change log. The goal of this file is to help readers
+    understand changes between version. The primary audience is
+    end users and integrators. Purely technical changes such as
+    code refactoring must not be mentioned here.
+    
+    This file may contain ONE level of section titles, underlined
+    with the ~ (tilde) character. Other section markers are
+    forbidden and will likely break the structure of the README.rst
+    or other documents where this fragment is included. ]
+
+Next
+~~~~
+
+* [ADD] Default "related action" for jobs, opening a form or list view (when
+  the job is linked to respectively one record on several).
+  (`#79 <https://github.com/OCA/queue/pull/79>`_, backport from `#46 <https://github.com/OCA/queue/pull/46>`_)
+
+10.0.1.0.0
+~~~~~~~~~~
+
+* Starting the changelog from there


### PR DESCRIPTION
Backport from #46

The related action button now opens by default the record on which the
job is working. It uses the default views of the job. The exact behavior
depends of the number of records in the job:

* No record (job called on a  model): display a message indicating that
there is no available action
* One record: open the default view in form
* Several records: open the default view in list

The related action can still be overridden by the 'related_action'
decorator.