### PR TITLE
[FIX] queue_job: Extract `method_name` from `func_name`

### DIFF
--- a/queue_job/migrations/10.0.1.0.0/post-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/post-migration.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    """Extract from old `func_name` field the name of the method to be put
+    on `method_name`.
+    """
+    if not version:
+        return
+    cr.execute(
+        """UPDATE queue_job
+        SET method_name = reverse(split_part(reverse(func_name), '.', 1))"""
+    )


### PR DESCRIPTION
Extract from old `func_name` field the name of the method to be put on `method_name`.

If not, pending jobs won't be properly executed, as the function name for being run is missing.

@Tecnativa