### PR TITLE
[10.0][FIX]queue_job: search jobs with same identity key must be done with sudo()

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -301,7 +301,7 @@ class Job(object):
 
     def job_record_with_same_identity_key(self):
         """Check if a job to be executed with the same key exists."""
-        existing = self.env['queue.job'].search(
+        existing = self.env['queue.job'].sudo().search(
             [('identity_key', '=', self.identity_key),
              ('state', 'in', [PENDING, ENQUEUED])],
             limit=1


### PR DESCRIPTION
When doing a search, it must be done in sudo() otherwise users which are not in the group `Job Queue Manager` will get a security error.
It can occurs when process launch a job throug a `.delay` instruction.