### PR TITLE
[FIX] queue: AutoVacuum cron changes

### DIFF
--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -18,6 +18,7 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall"/>
+            <field name="state">code</field>
             <field name="code">model.autovacuum()</field>
         </record>
 


### PR DESCRIPTION
By default, odoo uses state='object_write', so we need to specify it to state='code' for AutoVacuum cron job

Before PR:
![image](https://user-images.githubusercontent.com/4667326/49370040-067e8c80-f719-11e8-8e76-8cf1a1094693.png)

After PR:
![image](https://user-images.githubusercontent.com/4667326/49370005-e8b12780-f718-11e8-9a16-b9c86ec0a7f6.png)
