### PR TITLE
[10.0][IMP] queue_job: Don't prefetch fields when vacuum + bumpversion

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -3,7 +3,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.2.0.0',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue',
  'license': 'AGPL-3',


### PR DESCRIPTION
@guewen @lmignon 

Did this as sometimes, the amount of jobs is huge and there is no need fetching fields.