### PR TITLE
[IMP] queue: Store context in order to reuse it

### DIFF
--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -90,4 +90,5 @@ class Base(models.AbstractModel):
                                   max_retries=max_retries,
                                   description=description,
                                   channel=channel,
-                                  identity_key=identity_key)
+                                  identity_key=identity_key,
+                                  job_context=self.env.context.copy())

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -88,6 +88,7 @@ class QueueJob(models.Model):
                           index=True)
 
     identity_key = fields.Char()
+    job_context = JobSerialized(readonly=True)
 
     @api.model_cr
     def init(self):

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -36,7 +36,9 @@ class TestQueueJob(models.Model):
 
     name = fields.Char()
 
-    @job
+    @job(allow_context=[
+        'return_context_from_context', 'expected_element_from_context'
+    ])
     @related_action(action='testing_related_method')
     @api.multi
     def testing_method(self, *args, **kwargs):
@@ -47,6 +49,8 @@ class TestQueueJob(models.Model):
         if kwargs.get('raise_retry'):
             raise RetryableJobError('Must be retried later')
         if kwargs.get('return_context'):
+            return self.env.context
+        if self.env.context.get('return_context_from_context', False):
             return self.env.context
         return args, kwargs
 

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -5,7 +5,6 @@ import hashlib
 
 from datetime import datetime, timedelta
 import mock
-
 from odoo import SUPERUSER_ID
 import odoo.tests.common as common
 
@@ -529,6 +528,18 @@ class TestJobModel(common.TransactionCase):
         key_present = 'job_uuid' in result
         self.assertTrue(key_present)
         self.assertEqual(result['job_uuid'], test_job._uuid)
+
+    def test_context_from_context(self):
+        element = 'EXPECTED VALUE'
+        delayable = self.env['test.queue.job'].with_context(
+            return_context_from_context=True,
+            expected_element_from_context=element,
+        ).with_delay()
+        test_job = delayable.testing_method(return_context=True)
+        result = test_job.perform()
+        key_present = 'expected_element_from_context' in result
+        self.assertTrue(key_present)
+        self.assertEqual(result['expected_element_from_context'], element)
 
     def test_override_channel(self):
         delayable = self.env['test.queue.job'].with_delay(


### PR DESCRIPTION
With these PR, the context is stored and it can be used in the job.
Sometimes, you don't want to lose the context of the user.