### PR TITLE
[IMP] recordset jobs ignore non-existent records

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -261,9 +261,11 @@ class Job(object):
         method_name = stored.method_name
 
         model = env[stored.model_name]
-
-        recordset = model.browse(stored.record_ids)
-        method = getattr(recordset, method_name)
+        if stored.record_ids:
+            recordset = model.browse(stored.record_ids).exists()
+            method = getattr(recordset, method_name)
+        else:
+            method = getattr(model, method_name)
 
         eta = None
         if stored.eta:


### PR DESCRIPTION
When records underlying a recordset job have been deleted at
the time the job starts, ignore them instead of failing the job.

Closes #140 

This is WIP, untested.