### PR TITLE
[11.0] Retry postpone in a new transaction

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -71,10 +71,14 @@ class RunJobController(http.Controller):
         env = http.request.env(user=odoo.SUPERUSER_ID)
 
         def retry_postpone(job, message, seconds=None):
-            job.postpone(result=message, seconds=seconds)
-            job.set_pending(reset_retry=False)
-            job.store()
-            env.cr.commit()
+            job.env.clear()
+            with odoo.api.Environment.manage():
+                with odoo.registry(job.env.cr.dbname).cursor() as new_cr:
+                    job.env = job.env(cr=new_cr)
+                    job.postpone(result=message, seconds=seconds)
+                    job.set_pending(reset_retry=False)
+                    job.store()
+                    new_cr.commit()
 
         job = self._load_job(env, job_uuid)
         if job is None:


### PR DESCRIPTION
If the job's transaction fail with an OperationalError such as a
contraint failure, the transaction is broken and we will not be able
to postpone the job. Open a new transaction to change the job's state.

Port of:

- #41 from @2zx
- #130 from @liweijie0812