### PR TITLE
Show result of scheduled action in job

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -32,7 +32,7 @@ class IrCron(models.Model):
         if model_name in self.env:
             model = self.env[model_name]
             if hasattr(model, method_name):
-                getattr(model, method_name)(*args)
+                return getattr(model, method_name)(*args)
             else:
                 raise ValidationError(_("Method '%s.%s' does not exist." %
                                         (model_name, method_name)))


### PR DESCRIPTION
Scheduled action job invoke _run_job_as_queue_job.
The result of a job should be propagated to get job.result filled.
