### PR TITLE
[ADD] queue_job: dont_start_jobrunner/ODOO_QUEUE_JOB_DONT_START_JOBRUNNER

### DIFF
--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -56,6 +56,25 @@ class QueueJobRunnerThread(Thread):
 
 runner_thread = None
 
+
+def _is_runner_enabled():
+    return not _channels().strip().startswith('root:0')
+
+
+def _start_runner_thread(server_type):
+    global runner_thread
+    if not config['stop_after_init']:
+        if _is_runner_enabled():
+            _logger.info("starting jobrunner thread (in %s)",
+                         server_type)
+            runner_thread = QueueJobRunnerThread()
+            runner_thread.start()
+        else:
+            _logger.info("jobrunner thread (in %s) NOT started, " \
+                         "because the root channel's capacity is set to 0",
+                         server_type)
+
+
 orig_prefork_start = server.PreforkServer.start
 orig_prefork_stop = server.PreforkServer.stop
 orig_threaded_start = server.ThreadedServer.start
@@ -63,16 +82,8 @@ orig_threaded_stop = server.ThreadedServer.stop
 
 
 def prefork_start(server, *args, **kwargs):
-    global runner_thread
     res = orig_prefork_start(server, *args, **kwargs)
-    if not config['stop_after_init']:
-        if (_channels().strip().startswith('root:0')):
-            _logger.info("jobrunner thread (in prefork server) NOT started, " \
-                         "because the root channel's capacity is set to 0")
-        else:
-            _logger.info("starting jobrunner thread (in prefork server)")
-            runner_thread = QueueJobRunnerThread()
-            runner_thread.start()
+    _start_runner_thread("prefork server")
     return res
 
 
@@ -88,16 +99,8 @@ def prefork_stop(server, graceful=True):
 
 
 def threaded_start(server, *args, **kwargs):
-    global runner_thread
     res = orig_threaded_start(server, *args, **kwargs)
-    if not config['stop_after_init']:
-        if (_channels().strip().startswith('root:0')):
-            _logger.info("jobrunner thread (in threaded server) NOT started, " \
-                         "because the root channel's capacity is set to 0")
-        else:
-            _logger.info("starting jobrunner thread (in threaded server)")
-            runner_thread = QueueJobRunnerThread()
-            runner_thread.start()
+    _start_runner_thread("threaded server")
     return res
 
 

--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -10,7 +10,7 @@ import time
 from odoo.service import server
 from odoo.tools import config
 
-from .runner import QueueJobRunner
+from .runner import QueueJobRunner, _channels
 
 _logger = logging.getLogger(__name__)
 
@@ -66,9 +66,13 @@ def prefork_start(server, *args, **kwargs):
     global runner_thread
     res = orig_prefork_start(server, *args, **kwargs)
     if not config['stop_after_init']:
-        _logger.info("starting jobrunner thread (in prefork server)")
-        runner_thread = QueueJobRunnerThread()
-        runner_thread.start()
+        if (_channels().strip().startswith('root:0')):
+            _logger.info("jobrunner thread (in prefork server) NOT started, " \
+                         "because the root channel's capacity is set to 0")
+        else:
+            _logger.info("starting jobrunner thread (in prefork server)")
+            runner_thread = QueueJobRunnerThread()
+            runner_thread.start()
     return res
 
 
@@ -87,9 +91,13 @@ def threaded_start(server, *args, **kwargs):
     global runner_thread
     res = orig_threaded_start(server, *args, **kwargs)
     if not config['stop_after_init']:
-        _logger.info("starting jobrunner thread (in threaded server)")
-        runner_thread = QueueJobRunnerThread()
-        runner_thread.start()
+        if (_channels().strip().startswith('root:0')):
+            _logger.info("jobrunner thread (in threaded server) NOT started, " \
+                         "because the root channel's capacity is set to 0")
+        else:
+            _logger.info("starting jobrunner thread (in threaded server)")
+            runner_thread = QueueJobRunnerThread()
+            runner_thread.start()
     return res
 
 

--- a/queue_job/readme/HISTORY.rst
+++ b/queue_job/readme/HISTORY.rst
@@ -11,6 +11,8 @@
 Next
 ~~~~
 
+* [IMP] Dont' start the Jobrunner if root channel's capacity
+  is explicitly set to 0
 * [ADD] Ability to set several jobs to done using an multi-action
   (port of `#59 <https://github.com/OCA/queue/pull/59>`_)
 * [REF] Extract a method handling the post of a message when a job is failed,


### PR DESCRIPTION
This PR adds a new configuration parameter: `dont_start_jobrunner` (equivalent to `ODOO_QUEUE_JOB_DONT_START_JOBRUNNER` environment variable).

When explicitly set to `True`, the `QueueJobRunnerThread` won't be started.

One might say: if you don't want the Jobrunner to start, just don't add `queue_job` to `--load / server_wide_modules`.

Indeed, but there is one argument in favor of keeping the exact same `server_wide_modules` value for all instances of a one deployment.

Let's say you have 2 instances:
- `odoo1`, with `server_wide_modules = web,queue_job`
- `odoo2`, with `server_wide_modules = web`

If `odoo1` if configured not to process requests (`http_enable = False`), then all good: this instance only purpose will be to host the Jobrunner (and eventually to run scheduled actions if `max_cron_threads > 0`).

But if both of them are configured to process requests (`http_enable = True`), and trafic is load balanced between these 2 instances, you will notice that your assets bundles are continuously regenerated. That's because of a small snippet in the [backend templates](https://github.com/odoo/odoo/blob/11.0/addons/web/views/webclient_templates.xml#L140):

```
<script type="text/javascript" charset="utf-8">
            odoo._modules = <t t-raw="get_modules_order()"/>;
</script>
```

This [`get_modules_order()`](https://github.com/odoo/odoo/blob/11.0/odoo/addons/base/ir/ir_qweb/ir_qweb.py#L319) will [contain the list of modules in the exact order they were loaded](https://github.com/odoo/odoo/blob/11.0/addons/web/controllers/main.py#L181).

Given the difference in `server_wide_modules`, it won't return the exact same value for `odoo1` and `odoo2`, and thus the backend assets bundle checksum will be different: `odoo1` will continuously try to replace the bundle generated by `odoo2` and vice versa.

Another more straightforward argument in favor of this PR:
- in a high load context, it might be helpful to temporarily stop processing jobs
- to do so, it will be easier and more obvious to set `dont_start_jobrunner = True` than removing `queue_job` from `server_wide_modules`

If this PR is accepted, I'll backport/port it to 10.0/12.0 branches.