### PR TITLE
[11.0][base_import_async] - Add dependency to  queue_job_batch

### DIFF
--- a/base_import_async/__manifest__.py
+++ b/base_import_async/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Asynchronous Import',
     'summary': 'Import CSV files in the background',
-    'version': '11.0.1.0.0',
+    'version': '11.0.2.0.0',
     'author': 'Akretion, ACSONE SA/NV, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/queue',
@@ -15,6 +15,7 @@
     'depends': [
         'base_import',
         'queue_job',
+        'queue_job_batch',
     ],
     'data': [
         'views/base_import_async.xml',

--- a/base_import_async/readme/HISTORY.rst
+++ b/base_import_async/readme/HISTORY.rst
@@ -1,3 +1,9 @@
+11.0.2.0.0 (2019-07-08)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add dependency with module 'queue_job_batch', allowing the user to display
+  the progress of the import from the top bar.
+
 11.0.1.0.0 (2018-06-26)
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds to the 'base_import_o' module the dependency with 'queue_job_batch' so that the end user can track the progress of the load.

![Peek 2019-07-08 13-16](https://user-images.githubusercontent.com/7683926/60806223-b79f4680-a182-11e9-9712-68f8f3e4c869.gif)
