### PR TITLE
pre_init_hook to re-queue stuck jobs on module init

### DIFF
--- a/queue_job/__init__.py
+++ b/queue_job/__init__.py
@@ -2,3 +2,8 @@ from . import controllers
 from . import fields
 from . import models
 from . import jobrunner
+
+
+def pre_init_hook(cr):
+    cr.execute("update queue_job set state='pending' "
+               "where state in ('started', 'enqueued')")

--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -21,4 +21,5 @@
  'installable': True,
  'development_status': 'Mature',
  'maintainers': ['guewen'],
+'pre_init_hook': 'pre_init_hook',
  }


### PR DESCRIPTION
this is a concept, but I was wandering if there are cases why is this not already included, since jobs after the start of odoo that are in states `enqueued` and `started` are always stuck jobs.