### PR TITLE
[12.0][FIX] Autovacuum cron job

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '12.0.1.0.0',
+ 'version': '12.0.1.0.1',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue/queue_job',
  'license': 'AGPL-3',

--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -18,6 +18,7 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall"/>
+            <field name="state">code</field>
             <field name="code">model.autovacuum()</field>
         </record>
 

--- a/queue_job/migrations/12.0.1.0.1/post-migration.py
+++ b/queue_job/migrations/12.0.1.0.1/post-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Versada UAB
+# License AGPL-3 or later (https://www.gnu.org/licenses/agpl).
+
+import odoo
+
+
+def migrate(cr, version):
+    """Set "AutoVacuum Job Queue" cron job `state` to `code."""
+    if not version:
+        return
+    with odoo.api.Environment.manage():
+        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        cron_job = env.ref(
+            'queue_job.ir_cron_autovacuum_queue_jobs',
+            raise_if_not_found=False)
+        if cron_job and cron_job.exists() and cron_job.state != 'code':
+            cron_job.state = 'code'

--- a/test_queue_job/tests/__init__.py
+++ b/test_queue_job/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_autovacuum
 from . import test_job
 from . import test_job_channels
 from . import test_related_actions

--- a/test_queue_job/tests/test_autovacuum.py
+++ b/test_queue_job/tests/test_autovacuum.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Versada UAB
+# License AGPL-3 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from odoo.tests import common
+
+from odoo.addons.queue_job.job import Job
+
+
+class TestQueueJobAutovacuumCronJob(common.TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.queue_job = self.env['queue.job']
+        self.method = self.env['test.queue.job'].testing_method
+        self.cron_job = self.env.ref('queue_job.ir_cron_autovacuum_queue_jobs')
+
+    def test_old_jobs_are_deleted(self):
+        """
+        Old jobs are deleted by the autovacuum cron job.
+        """
+        test_job = Job(self.method)
+        test_job.set_done(result='ok')
+        test_job.date_done = datetime.datetime.now() - datetime.timedelta(
+            days=self.queue_job._removal_interval + 1)
+        test_job.store()
+
+        self.cron_job.method_direct_trigger()
+
+        self.assertFalse(test_job.db_record().exists())


### PR DESCRIPTION
`state` is not set to `code` on the _AutoVacuum Job Queue_ `ir.cron` [data record](https://github.com/OCA/queue/blob/3682aae2970ccc1c6c3e8ee3a76464b09cbe8118/queue_job/data/queue_data.xml#L12-L22), so the [default action](https://github.com/odoo/odoo/blob/ead2d19e4a9cb25e1953e8528face4090079ae1d/odoo/addons/base/models/ir_actions.py#L375) `object_write` is assigned to it on creation, as a result, the cron job does nothing when it runs (jobs older than 30 days are not being deleted).

Affected versions: 12.0, this was already fixed for 11.0 in #112

I've also added a test case and a migration to update the record for existing installations (since the record is marked as `noupdate="1"`).

If, like me, you did not notice it for quite a while and now have hundreds of thousands of old jobs (or even more), running the fixed autovacuum cron job will most likely fail due to memory error or a timeout (depends on the setup, of course). To work around that, I've copied the original _AutoVacuum Job Queue_ cron job record and used this for `code`:

```python
deadline = datetime.datetime.now() - datetime.timedelta(days=31)
model.search([('date_done', '<=', deadline)], limit=10000).unlink()
```
and setup to run this Cron job e.g. every 5 minutes to clear away the build-up.
