### PR TITLE
[12.0][IMP] Link to OCA Guidelines page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # OCA Guidelines
 
-Please follow the official guide from the [OCA Guidelines page](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md).
+Please follow the official guide from the [OCA Guidelines page](https://odoo-community.org/page/contributing).
 
 ## Project Specific Guidelines
 


### PR DESCRIPTION
Currently, when creating a PR/issue for the first time, the GitHub contribution helper pop-up links to this page, so it becomes a redirect to a redirect.