### PR TITLE
[13.0] pre-commit: unexclude installable addons

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "^setup/|/static/lib/|/static/src/lib/|^base_export_async/|^base_import_async/|^queue_job/|^queue_job_cron/|^queue_job_subscribe/|^test_base_import_async/|^test_queue_job/"
+exclude: "^setup/|/static/lib/|/static/src/lib/|^base_export_async/|^base_import_async/|^test_base_import_async/|^test_queue_job/"
 default_language_version:
   python: python3
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "^setup/|/static/lib/|/static/src/lib/|^base_export_async/|^base_import_async/|^test_base_import_async/|^test_queue_job/"
+exclude: "^setup/|/static/lib/|/static/src/lib/|^base_export_async/|^base_import_async/|^test_base_import_async/"
 default_language_version:
   python: python3
 repos:

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -13,6 +13,11 @@ valid_odoo_versions=13.0
 [MESSAGES CONTROL]
 disable=all
 
+# missing-manifest-dependency
+# has been removed from the checks
+# until https://github.com/OCA/pylint-odoo/pull/263
+# is released
+
 enable=anomalous-backslash-in-string,
     api-one-deprecated,
     api-one-multi-together,
@@ -39,7 +44,6 @@ enable=anomalous-backslash-in-string,
     method-required-super,
     method-search,
     missing-import-error,
-    missing-manifest-dependency,
     openerp-exception-warning,
     pointless-statement,
     pointless-string-statement,


### PR DESCRIPTION
Tentative to fix #178 

I added a commit on top of @sbidoul's one to temporarily remove the `missing-manifest-dependency` check from pylint.

It can be removed as soon as OCA/pylint-odoo#263 is included in a pylint-odoo release.

The risk of having a new dependency in the queue addons is lower than excluding every addons from pre-commit checks.
