### PR TITLE
[10.0][FIX] queue_job: vaccuum query must be based on channel complete name

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -249,7 +249,7 @@ class QueueJob(models.Model):
                 days=int(channel.removal_interval))
             jobs = self.search(
                 [('date_done', '<=', fields.Datetime.to_string(deadline)),
-                 ('channel', '=', channel.name)],
+                 ('channel', '=', channel.complete_name)],
             )
             if jobs:
                 jobs.unlink()

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -549,7 +549,7 @@ class TestJobModel(common.TransactionCase):
         job_root = self._create_job()
         job_root.write({'date_done': date_done})
         job_60days = self._create_job()
-        job_60days.write({'channel': channel_60days.name,
+        job_60days.write({'channel': channel_60days.complete_name,
                           'date_done': date_done})
 
         self.assertEqual(len(self.env['queue.job'].search([])), 2)


### PR DESCRIPTION
If you use hierarchical channels, the name stored on the queue job in the complete path.
So the search for vacuuming should use it to retrieve jobs to clean