### PR TITLE
[10.0][IMP] queue_job: don't start Jobrunner if root channel's capacity is explicitly set to 0 - backport from 11.0

### DIFF
--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -11,7 +11,7 @@ import time
 from odoo.service import server
 from odoo.tools import config
 
-from .runner import QueueJobRunner
+from .runner import QueueJobRunner, _channels
 
 _logger = logging.getLogger(__name__)
 
@@ -59,6 +59,25 @@ class QueueJobRunnerThread(Thread):
 
 runner_thread = None
 
+
+def _is_runner_enabled():
+    return not _channels().strip().startswith('root:0')
+
+
+def _start_runner_thread(server_type):
+    global runner_thread
+    if not config['stop_after_init']:
+        if _is_runner_enabled():
+            _logger.info("starting jobrunner thread (in %s)",
+                         server_type)
+            runner_thread = QueueJobRunnerThread()
+            runner_thread.start()
+        else:
+            _logger.info("jobrunner thread (in %s) NOT started, " \
+                         "because the root channel's capacity is set to 0",
+                         server_type)
+
+
 orig_prefork_start = server.PreforkServer.start
 orig_prefork_stop = server.PreforkServer.stop
 orig_threaded_start = server.ThreadedServer.start
@@ -66,12 +85,8 @@ orig_threaded_stop = server.ThreadedServer.stop
 
 
 def prefork_start(server, *args, **kwargs):
-    global runner_thread
     res = orig_prefork_start(server, *args, **kwargs)
-    if not config['stop_after_init']:
-        _logger.info("starting jobrunner thread (in prefork server)")
-        runner_thread = QueueJobRunnerThread()
-        runner_thread.start()
+    _start_runner_thread("prefork server")
     return res
 
 
@@ -87,12 +102,8 @@ def prefork_stop(server, graceful=True):
 
 
 def threaded_start(server, *args, **kwargs):
-    global runner_thread
     res = orig_threaded_start(server, *args, **kwargs)
-    if not config['stop_after_init']:
-        _logger.info("starting jobrunner thread (in threaded server)")
-        runner_thread = QueueJobRunnerThread()
-        runner_thread.start()
+    _start_runner_thread("threaded server")
     return res
 
 

--- a/queue_job/readme/HISTORY.rst
+++ b/queue_job/readme/HISTORY.rst
@@ -2,7 +2,7 @@
     understand changes between version. The primary audience is
     end users and integrators. Purely technical changes such as
     code refactoring must not be mentioned here.
-    
+
     This file may contain ONE level of section titles, underlined
     with the ~ (tilde) character. Other section markers are
     forbidden and will likely break the structure of the README.rst
@@ -11,6 +11,8 @@
 Next
 ~~~~
 
+* [IMP] Dont' start the Jobrunner if root channel's capacity is explicitly set
+  to 0 (backport from `#148 <https://github.com/OCA/queue/pull/148>`_)
 * [ADD] Default "related action" for jobs, opening a form or list view (when
   the job is linked to respectively one record on several).
   (`#79 <https://github.com/OCA/queue/pull/79>`_, backport from `#46 <https://github.com/OCA/queue/pull/46>`_)


### PR DESCRIPTION
backport https://github.com/OCA/queue/pull/148