### PR TITLE
[FIX] Flush pending updates immediately when storing job data

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -31,6 +31,7 @@ class RunJobController(http.Controller):
         job.perform()
         job.set_done()
         job.store()
+        env["base"].flush()
         env.cr.commit()
         _logger.debug("%s done", job)
 


### PR DESCRIPTION
Odoo 13 introduced [flush](https://github.com/odoo/odoo/blob/f4ae831df40e803d1c4d7f9f39751b849b79021b/odoo/models.py#L5359) method, that is required after you execute `write` method.

Without this, jobs' db records may not be updated after env.cr.commit(), that could lead when job actually is done, while job's db record is not.