### PR TITLE
[FIX] queue_job_cron: use the complete name of the channel when launching a cron

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -46,7 +46,7 @@ class IrCron(models.Model):
             return self.with_delay(
                 priority=cron.priority,
                 description=cron.name,
-                channel=cron.channel_id.name)._run_job_as_queue_job(
+                channel=cron.channel_id.complete_name)._run_job_as_queue_job(
                     model_name=model_name,
                     method_name=method_name,
                     args=args)

--- a/queue_job_cron/tests/test_queue_job_cron.py
+++ b/queue_job_cron/tests/test_queue_job_cron.py
@@ -30,7 +30,7 @@ class TestQueueJobCron(TransactionCase):
         self.assertEqual(qjob.name, cron.name)
         self.assertEqual(qjob.priority, cron.priority)
         self.assertEqual(qjob.user_id, cron.user_id)
-        self.assertEqual(qjob.channel, cron.channel_id.name)
+        self.assertEqual(qjob.channel, cron.channel_id.complete_name)
 
     def test_queue_job_cron_onchange(self):
         cron = self.env.ref('queue_job.ir_cron_autovacuum_queue_jobs')


### PR DESCRIPTION
I just notice that cron are launched using only the channel name and not the complete name.
This PR aims to fixe that