### PR TITLE
avoid singleton error to search function job

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -117,7 +117,7 @@ class QueueJob(models.Model):
             method = getattr(model, record.method_name)
             channel_method_name = channel_func_name(method)
             func_model = self.env['queue.job.function']
-            function = func_model.search([('name', '=', channel_method_name)])
+            function = func_model.search([('name', '=', channel_method_name)], limit=1)
             record.channel_method_name = channel_method_name
             record.job_function_id = function
 


### PR DESCRIPTION
Hi,

By any unknown reason 2 records was create on `queue.job.function`, it raise error to calculate field [job_function_id ](https://github.com/OCA/queue/blob/38b2f656714685bf2807ad076920e48663ff3c7f/queue_job/models/queue_job.py#L69)

![quee job function](https://user-images.githubusercontent.com/7775116/83915690-618fa600-a739-11ea-8f17-8e073212bb50.png)

![error quee](https://user-images.githubusercontent.com/7775116/83915633-41f87d80-a739-11ea-83b8-522c7c25fef2.png)

limit search to 1 record avoid error
