### PR TITLE
[13.0] Fix interrupt error handling on select

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -524,15 +524,14 @@ class QueueJobRunner(object):
                     self.wait_notification()
             except KeyboardInterrupt:
                 self.stop()
-            except Exception as e:
+            except InterruptedError:
                 # Interrupted system call, i.e. KeyboardInterrupt during select
-                if isinstance(e, select.error) and e[0] == 4:
-                    self.stop()
-                else:
-                    _logger.exception(
-                        "exception: sleeping %ds and retrying", ERROR_RECOVERY_DELAY
-                    )
-                    self.close_databases()
-                    time.sleep(ERROR_RECOVERY_DELAY)
+                self.stop()
+            except Exception:
+                _logger.exception(
+                    "exception: sleeping %ds and retrying", ERROR_RECOVERY_DELAY
+                )
+                self.close_databases()
+                time.sleep(ERROR_RECOVERY_DELAY)
         self.close_databases(remove_jobs=False)
         _logger.info("stopped")


### PR DESCRIPTION
When select has an interruption, it raises an error with an EINTR errno.
The exception's errno is not (no longer?) available with an index:

TypeError: 'OSError' object is not subscriptable

Since Python 3.5, select() now raises an InterruptedError.
Alternatively, we could check if e.errno == errno.EINTR.

Fixes #240
