### PR TITLE
[FIX] force binary file type

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -101,7 +101,8 @@ class BaseImportImport(models.TransientModel):
         attachment = self.env['ir.attachment'].create({
             'name': file_name,
             'datas': datas,
-            'datas_fname': file_name
+            'datas_fname': file_name,
+            'type': 'binary'
         })
         return attachment
 


### PR DESCRIPTION
* Purpose
Force attachment for async import as 'binary'
For unknown reason, possibly a "default_type" key in context, the attachment
has been created with a value "product" for the type, which fails with an
exception because this type is invalid.
Even if the root cause is not known yet, forcing the type as binary is more
defensive and always the value we expect.