### PR TITLE
[13.0] Add job_serialized in IrModelFields.ttype selection

### DIFF
--- a/queue_job/models/__init__.py
+++ b/queue_job/models/__init__.py
@@ -1,2 +1,3 @@
 from . import base
+from . import ir_model_fields
 from . import queue_job

--- a/queue_job/models/ir_model_fields.py
+++ b/queue_job/models/ir_model_fields.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Camptocamp
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo import fields, models
+
+
+class IrModelFields(models.Model):
+    _inherit = "ir.model.fields"
+
+    ttype = fields.Selection(selection_add=[("job_serialized", "Job Serialized")])


### PR DESCRIPTION
## Context

The queue_job module adds a new type of field, with the type
"job_serialized", which is close to the base "serialized" field,
adding support of serialization for recordsets and a couple of common
types such as datetime and date.

This field type is used in several fields of the "queue.job" model.

In "ir.model.fields", each field is related to a "ttype", which is
a selection containing every types of fields supported by the current
database.

The "job_serialized" field was never registered as a possible value for
the ttype selection field. It seems it had never been an issue before
Odoo 13.0. With Odoo 13.0, we may have this error on upgrades:

```
INFO sample odoo.modules.loading: 297 modules loaded in 529.51s, 0 queries
INFO sample odoo.addons.base.models.ir_model: Deleting 4@ir.model.fields.selection (base.selection__ir_model_fields__ttype__job_serialized)
ERROR sample odoo.sql_db: bad query: UPDATE "ir_model_fields" SET "ttype"=NULL WHERE "ttype"='job_serialized'
ERROR: null value in column "ttype" violates not-null constraint
DETAIL:  Failing row contains (4296, record_ids, null, queue.job, null, null, null, 266, Record, null, null, t, null, null, f, t, f, f, null, base, null, null, t, null, null, null, null, null, t, null, null, 1, 2020-08-11 13:03:09.913127, null, null).

2020-08-11 13:10:53,168 167 WARNING sample odoo.modules.loading: Transient module states were reset
2020-08-11 13:10:53,170 167 ERROR sample odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/odoo/src/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 472, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/odoo/src/odoo/addons/base/models/ir_model.py", line 1990, in _process_end
    record.unlink()
  File "/odoo/src/odoo/addons/base/models/ir_model.py", line 1208, in unlink
    self.env.cr.execute(query, [selection.value])
  File "/odoo/src/odoo/sql_db.py", line 168, in wrapper
    return f(self, *args, **kwargs)
  File "/odoo/src/odoo/sql_db.py", line 245, in execute
    res = self._obj.execute(query, params)
psycopg2.IntegrityError: null value in column "ttype" violates not-null constraint
DETAIL:  Failing row contains (4296, record_ids, null, queue.job, null, null, null, 266, Record, null, null, t, null, null, f, t, f, f, null, base, null, null, t, null, null, null, null, null, t, null, null, 1, 2020-08-11 13:03:09.913127, null, null).
```

## Explanation

In 13.0, a model "ir.model.fields.selection" storing the allowed
selection for a field has been added
(https://github.com/odoo/odoo/commit/7593b887dff4fcd474ca72aead6825481b419d86).

When the "job_serialized" fields for queue_job are created, they are
properly created in ir.model.fields with "job_serialized" as "ttype".
It creates the entry in "ir.model.fields.selection".

When we update the module, if it does not find "job_serialized" as a
possible value for IrModelFields.ttype, it unlinks the entry in
"ir.model.fields.selection". When this happens, an override of the
"unlink()" method in "ir.model.fields.selection" force a NULL value in
the selection fields (here IrModelFields.ttype).

Fixes: #227
