### PR TITLE
Do not save session in /queue_job/runjob route

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -34,19 +34,7 @@ class RunJobController(http.Controller):
         env.cr.commit()
         _logger.debug("%s done", job)
 
-    @http.route("/queue_job/session", type="http", auth="none")
-    def session(self):
-        """Used by the jobrunner to spawn a session
-
-        The queue jobrunner uses anonymous sessions when it calls
-        ``/queue_job/runjob``.  To avoid having thousands of anonymous
-        sessions, before running jobs, it creates a ``requests.Session``
-        and does a GET on ``/queue_job/session``, providing it a cookie
-        which will be used for subsequent calls to runjob.
-        """
-        return ""
-
-    @http.route("/queue_job/runjob", type="http", auth="none")
+    @http.route("/queue_job/runjob", type="http", auth="none", save_session=False)
     def runjob(self, db, job_uuid, **kw):
         http.request.session.db = db
         env = http.request.env(user=odoo.SUPERUSER_ID)

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -157,9 +157,6 @@ ERROR_RECOVERY_DELAY = 5
 _logger = logging.getLogger(__name__)
 
 
-session = requests.Session()
-
-
 # Unfortunately, it is not possible to extend the Odoo
 # server command line arguments, so we resort to environment variables
 # to configure the runner (channels mostly).
@@ -201,20 +198,7 @@ def _connection_info_for(db_name):
     return connection_info
 
 
-session = requests.Session()
-
-
 def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
-    if not session.cookies:
-        # obtain an anonymous session
-        _logger.info("obtaining an anonymous session for the job runner")
-        url = "{}://{}:{}/queue_job/session".format(scheme, host, port)
-        auth = None
-        if user:
-            auth = (user, password)
-        response = session.get(url, timeout=30, auth=auth)
-        response.raise_for_status()
-
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
@@ -250,7 +234,7 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
                 auth = (user, password)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = session.get(url, timeout=1, auth=auth)
+            response = requests.get(url, timeout=1, auth=auth)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error
@@ -260,7 +244,6 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
             set_job_pending()
         except Exception:
             _logger.exception("exception in GET %s", url)
-            session.cookies.clear()
             set_job_pending()
 
     thread = threading.Thread(target=urlopen)


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/f65528a74e8d3f11cadd8658f5495bba21338199 routes have a `save_session` option.

We can simplify the job runner by making use of it.

This is currently lUNTESTED.