### PR TITLE
[13.0][ADD] queue_job: innocuous test job for debugging/monitoring purposes

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -7,6 +7,7 @@ import traceback
 from io import StringIO
 
 from psycopg2 import OperationalError
+from werkzeug.exceptions import Forbidden
 
 import odoo
 from odoo import _, http, tools
@@ -108,3 +109,35 @@ class RunJobController(http.Controller):
             raise
 
         return ""
+
+    @http.route("/queue_job/create_test_job", type="http", auth="user")
+    def create_test_job(
+        self, priority=None, max_retries=None, channel="root", description="Test job"
+    ):
+        if not http.request.env.user.has_group("base.group_erp_manager"):
+            raise Forbidden(_("Access Denied"))
+
+        if priority is not None:
+            try:
+                priority = int(priority)
+            except ValueError:
+                priority = None
+
+        if max_retries is not None:
+            try:
+                max_retries = int(max_retries)
+            except ValueError:
+                max_retries = None
+
+        delayed = (
+            http.request.env["queue.job"]
+            .with_delay(
+                priority=priority,
+                max_retries=max_retries,
+                channel=channel,
+                description=description,
+            )
+            ._test_job()
+        )
+
+        return delayed.db_record().uuid

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -8,7 +8,7 @@ from odoo import _, api, exceptions, fields, models
 from odoo.osv import expression
 
 from ..fields import JobSerialized
-from ..job import DONE, PENDING, STATES, Job
+from ..job import DONE, PENDING, STATES, Job, job
 
 _logger = logging.getLogger(__name__)
 
@@ -304,6 +304,10 @@ class QueueJob(models.Model):
                 }
             )
         return action
+
+    @job
+    def _test_job(self):
+        _logger.info("Running test job.")
 
 
 class RequeueJob(models.TransientModel):


### PR DESCRIPTION
The goal of this PR is to introduce an easy and innocuous way to confirm that jobs are running fine in a production environment, by triggering the creation of a test job through an http route.

Of course, only accessible to admin users to avoid any abuse :)