### PR TITLE
[13.0][ADD] queue_job: db listener

### DIFF
--- a/queue_job/__init__.py
+++ b/queue_job/__init__.py
@@ -3,3 +3,4 @@ from . import fields
 from . import models
 from . import jobrunner
 from .hooks.post_init_hook import post_init_hook
+from .hooks.uninstall_hook import uninstall_hook

--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -21,4 +21,5 @@
     "development_status": "Mature",
     "maintainers": ["guewen"],
     "post_init_hook": "post_init_hook",
+    "uninstall_hook": "uninstall_hook",
 }

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -142,3 +142,16 @@ class RunJobController(http.Controller):
         )
 
         return delayed.db_record().uuid
+
+    @http.route("/queue_job/notify_db_listener", type="http", auth="user")
+    def notify_db_listener(self, action="add"):
+        if not http.request.env.user.has_group("base.group_erp_manager"):
+            raise Forbidden(_("Access Denied"))
+
+        with odoo.sql_db.db_connect("postgres").cursor() as cr_postgres:
+            cr_postgres.execute(
+                "notify queue_job_db_listener, %s",
+                ("{} {}".format(action, http.request.env.cr.dbname),),
+            )
+
+        return ""

--- a/queue_job/hooks/uninstall_hook.py
+++ b/queue_job/hooks/uninstall_hook.py
@@ -1,0 +1,15 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+
+import odoo
+
+logger = logging.getLogger(__name__)
+
+
+def uninstall_hook(cr, registry):
+    logger.info("Notify jobrunner to remove this db")
+    with odoo.sql_db.db_connect("postgres").cursor() as cr_postgres:
+        cr_postgres.execute(
+            "notify queue_job_db_listener, %s", ("remove {}".format(cr.dbname),)
+        )

--- a/queue_job/jobrunner/dblistener.py
+++ b/queue_job/jobrunner/dblistener.py
@@ -1,0 +1,76 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+import select
+import time
+from threading import Thread
+
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+SELECT_TIMEOUT = 60
+ERROR_RECOVERY_DELAY = 5
+
+_logger = logging.getLogger(__name__)
+
+
+class DBListenerThread(Thread):
+    def __init__(self, jobrunner, connection_info):
+        Thread.__init__(self)
+        self.daemon = True
+        self.listener = DBListener(jobrunner, connection_info)
+
+    def run(self):
+        self.listener.run()
+
+    def stop(self):
+        self.listener.stop()
+
+
+class DBListener(object):
+    def __init__(self, jobrunner, connection_info):
+        self.jobrunner = jobrunner
+        self.connection_info = connection_info
+
+    def run(self):
+        while not self.jobrunner._stop:
+            try:
+                _logger.info(
+                    "connecting to db postgres@%(host)s:%(port)s", self.connection_info,
+                )
+                conn = psycopg2.connect(**self.connection_info)
+                conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+                with conn.cursor() as cr:
+                    cr.execute("listen queue_job_db_listener")
+                    conn.commit()
+                    while True:
+                        if select.select([conn], [], [], SELECT_TIMEOUT) == (
+                            [],
+                            [],
+                            [],
+                        ):
+                            pass
+                        else:
+                            conn.poll()
+                            while conn.notifies:
+                                payload = conn.notifies.pop().payload
+                                _logger.info("received notification: %s", payload)
+                                if payload.startswith("add"):
+                                    db_name = payload[4:]
+                                    # the module state is changed to installed in
+                                    # a different transaction than its installation:
+                                    # https://github.com/odoo/odoo/blob/aeebe275
+                                    # /odoo/modules/loading.py#L266
+                                    # so we wait a bit
+                                    time.sleep(2)
+                                    self.jobrunner.initialize_database(db_name)
+                                elif payload.startswith("remove"):
+                                    db_name = payload[7:]
+                                    self.jobrunner.close_database(
+                                        db_name, remove_jobs=True
+                                    )
+            except Exception:
+                _logger.exception(
+                    "exception: sleeping %ds and retrying", ERROR_RECOVERY_DELAY
+                )
+                time.sleep(ERROR_RECOVERY_DELAY)


### PR DESCRIPTION
The goal of this PR is to introduce an opt-in mechanism to enable the jobrunner to take into account changes happening after server launch.

For now, it is focused on databases:
- addition (installation of the module on a new or existing database)
- removal (uninstallation of the module from a database).

Beyond the post_init/uninstall hooks, an http route is added to enable admins to manually trigger addition/removal events for a given database.
