### PR TITLE
[ON HOLD][13.0] Add job_auto_delay decorator

### DIFF
--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -4,7 +4,7 @@
 from odoo import fields, models
 
 from odoo.addons.queue_job.exception import RetryableJobError
-from odoo.addons.queue_job.job import job, related_action
+from odoo.addons.queue_job.job import job, job_auto_delay, related_action
 
 
 class QueueJob(models.Model):
@@ -68,6 +68,19 @@ class TestQueueJob(models.Model):
         mutable_arg.append(2)
         mutable_kwarg["b"] = 2
         return mutable_arg, mutable_kwarg
+
+    @job_auto_delay
+    def delay_me(self, arg, kwarg=None):
+        return arg, kwarg
+
+    def delay_me_options_job_options(self):
+        return {
+            "identity_key": "my_job_identity",
+        }
+
+    @job_auto_delay
+    def delay_me_options(self):
+        return "ok"
 
 
 class TestQueueChannel(models.Model):

--- a/test_queue_job/tests/__init__.py
+++ b/test_queue_job/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_autovacuum
 from . import test_job
+from . import test_job_auto_delay
 from . import test_job_channels
 from . import test_related_actions

--- a/test_queue_job/tests/test_job_auto_delay.py
+++ b/test_queue_job/tests/test_job_auto_delay.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo.addons.queue_job.job import Job
+
+from .common import JobCommonCase
+
+
+class TestJobAutoDelay(JobCommonCase):
+    """Test auto delay of jobs"""
+
+    def test_auto_delay(self):
+        """method decorated by @job_auto_delay is automatically delayed"""
+        result = self.env["test.queue.job"].delay_me(1, kwarg=2)
+        self.assertTrue(isinstance(result, Job))
+        self.assertEqual(result.args, (1,))
+        self.assertEqual(result.kwargs, {"kwarg": 2})
+
+    def test_auto_delay_options(self):
+        """method automatically delayed une <method>_job_options arguments"""
+        result = self.env["test.queue.job"].delay_me_options()
+        self.assertTrue(isinstance(result, Job))
+        self.assertEqual(result.identity_key, "my_job_identity")
+
+    def test_auto_delay_inside_job(self):
+        """when a delayed job is processed, it must not delay itself"""
+        job_ = self.env["test.queue.job"].delay_me(1, kwarg=2)
+        self.assertTrue(job_.perform(), (1, 2))
+
+    def test_auto_delay_force_sync(self):
+        """method forced to run synchronously"""
+        result = (
+            self.env["test.queue.job"]
+            .with_context(_job_force_sync=True)
+            .delay_me(1, kwarg=2)
+        )
+        self.assertTrue(result, (1, 2))


### PR DESCRIPTION
This is a new decorator, to use instead of `@job` on methods,
that transforms a method to a method automatically delayed as job when
called.

A typical use case is when a method in a module we don't control is called
synchronously in the middle of another method, and we'd like all the calls
to this method become asynchronous.

Closes #238