### PR TITLE
Store 'su' flag in jobs

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -49,6 +49,7 @@ class QueueJob(models.Model):
     )
 
     uuid = fields.Char(string="UUID", readonly=True, index=True, required=True)
+    # maybe be better to keep this one out of "func_env" for searches?
     user_id = fields.Many2one(comodel_name="res.users", string="User ID", required=True)
     company_id = fields.Many2one(
         comodel_name="res.company", string="Company", index=True
@@ -58,6 +59,8 @@ class QueueJob(models.Model):
     model_name = fields.Char(string="Model", readonly=True)
     method_name = fields.Char(readonly=True)
     record_ids = JobSerialized(readonly=True, base_type=list)
+    # TODO store a context in func_env, based on https://github.com/OCA/queue/pull/121
+    func_env = JobSerialized(readonly=True, base_type=dict)
     args = JobSerialized(readonly=True, base_type=tuple)
     kwargs = JobSerialized(readonly=True, base_type=dict)
     func_string = fields.Char(

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -432,6 +432,28 @@ class TestJobs(JobCommonCase):
         self.assertEquals(([1],), job_instance.args)
         self.assertEquals({"mutable_kwarg": {"a": 1}}, job_instance.kwargs)
 
+    def test_store_env_su_no_sudo(self):
+        demo_user = self.env.ref("base.user_demo")
+        self.env = self.env(user=demo_user)
+        delayable = self.env["test.queue.job"].with_delay()
+        test_job = delayable.testing_method()
+        stored = test_job.db_record()
+        self.assertDictEqual(stored.func_env, {"su": False})
+        job_instance = Job.load(self.env, stored.uuid)
+        self.assertFalse(job_instance.env.su)
+        self.assertFalse(job_instance.recordset.env.su)
+
+    def test_store_env_su_sudo(self):
+        demo_user = self.env.ref("base.user_demo")
+        self.env = self.env(user=demo_user)
+        delayable = self.env["test.queue.job"].sudo().with_delay()
+        test_job = delayable.testing_method()
+        stored = test_job.db_record()
+        self.assertDictEqual(stored.func_env, {"su": True})
+        job_instance = Job.load(self.env, stored.uuid)
+        self.assertTrue(job_instance.env.su)
+        self.assertTrue(job_instance.recordset.env.su)
+
 
 class TestJobModel(JobCommonCase):
     def test_job_change_state(self):


### PR DESCRIPTION
"record.sudo().with_delay().foo()" generates a job that will be run
as sudo, keeping the current user, following the new implementation of
sudo/with_user of 13.0.

Closes #271 