### PR TITLE
[13.0] Fix channel name in jobs delayed for crons

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -36,7 +36,7 @@ class IrCron(models.Model):
             return self.with_delay(
                 priority=self.priority,
                 description=self.name,
-                channel=self.channel_id.name,
+                channel=self.channel_id.complete_name,
             )._run_job_as_queue_job(server_action=self.ir_actions_server_id)
         else:
             return super().method_direct_trigger()
@@ -48,7 +48,7 @@ class IrCron(models.Model):
             return self.with_delay(
                 priority=cron.priority,
                 description=cron.name,
-                channel=cron.channel_id.name,
+                channel=cron.channel_id.complete_name,
             )._run_job_as_queue_job(server_action=server_action)
         else:
             return super()._callback(

--- a/queue_job_cron/tests/test_queue_job_cron.py
+++ b/queue_job_cron/tests/test_queue_job_cron.py
@@ -26,7 +26,7 @@ class TestQueueJobCron(TransactionCase):
         self.assertEqual(qjob.name, cron.name)
         self.assertEqual(qjob.priority, cron.priority)
         self.assertEqual(qjob.user_id, cron.user_id)
-        self.assertEqual(qjob.channel, cron.channel_id.name)
+        self.assertEqual(qjob.channel, cron.channel_id.complete_name)
 
     def test_queue_job_cron_depends(self):
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")


### PR DESCRIPTION
The channel must be 'root.ir_cron', not 'ir_cron'.

Port of #276 