### PR TITLE
Remove warning when @job decorator is used

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -841,15 +841,21 @@ def job(func=None, default_channel="root", retry_pattern=None):
     if retry_pattern:
         xml_fields.append('    <field name="retry_pattern">{retry_pattern}</field>')
 
-    xml_record = (
-        '<record id="job_function_[insert model]_{method}"'
-        ' model="queue.job.function">\n' + "\n".join(xml_fields) + "\n</record>"
-    ).format(**{"method": func.__name__, "retry_pattern": retry_pattern})
-    _logger.warning(
-        "@job is deprecated and no longer needed, if you need custom options, "
-        "use an XML record:\n%s",
-        xml_record,
+    _logger.info(
+        "@job is deprecated and no longer needed (on %s), it is advised to use an "
+        "XML record (activate DEBUG log for snippet)",
+        func.__name__,
     )
+    if _logger.isEnabledFor(logging.DEBUG):
+        xml_record = (
+            '<record id="job_function_[insert model]_{method}"'
+            ' model="queue.job.function">\n' + "\n".join(xml_fields) + "\n</record>"
+        ).format(**{"method": func.__name__, "retry_pattern": retry_pattern})
+        _logger.debug(
+            "XML snippet (to complete) for replacing @job on %s:\n%s",
+            func.__name__,
+            xml_record,
+        )
 
     def delay_from_model(*args, **kwargs):
         raise AttributeError(
@@ -951,16 +957,21 @@ def related_action(action=None, **kwargs):
             '    <field name="related_action">{related_action}</field>'
         )
 
-        xml_record = (
-            '<record id="job_function_[insert model]_{method}"'
-            ' model="queue.job.function">\n' + xml_fields + "\n</record>"
-        ).format(**{"method": func.__name__, "related_action": action})
-        _logger.warning(
-            "@related_action is deprecated and no longer needed,"
-            " add these options in a 'queue.job.function'"
-            " XML record:\n%s",
-            xml_record,
+        _logger.info(
+            "@related_action is deprecated and no longer needed (on %s),"
+            " it is advised to use an XML record (activate DEBUG log for snippet)",
+            func.__name__,
         )
+        if _logger.isEnabledFor(logging.DEBUG):
+            xml_record = (
+                '<record id="job_function_[insert model]_{method}"'
+                ' model="queue.job.function">\n' + xml_fields + "\n</record>"
+            ).format(**{"method": func.__name__, "related_action": action})
+            _logger.debug(
+                "XML snippet (to complete) for replacing @related_action on %s:\n%s",
+                func.__name__,
+                xml_record,
+            )
 
         func.related_action = action
         func.kwargs = kwargs


### PR DESCRIPTION
It makes the runbot builds fail. There is no urgency to remove the
decorator even if we should incentivize the removal because it is
no longer supported, hence the info log. Also, show only the XML snippet
when debug logs are active, because it is too verbose.

Following #274 