### PR TITLE
[13.0] Refactor storage of job records with "sudo" support

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Job Queue",
-    "version": "13.0.3.1.0",
+    "version": "13.0.3.2.0",
     "author": "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/queue/queue_job",
     "license": "LGPL-3",

--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -27,18 +27,29 @@ class JobSerialized(fields.Field):
 
     _slots = {"_base_type": type}
 
-    _default_json_mapping = {dict: "{}", list: "[]", tuple: "[]"}
+    # these are the default values when we convert an empty value
+    _default_json_mapping = {
+        dict: "{}",
+        list: "[]",
+        tuple: "[]",
+        models.BaseModel: lambda env: json.dumps(
+            {"_type": "odoo_recordset", "model": "base", "ids": [], "uid": env.uid}
+        ),
+    }
 
     def __init__(self, string=fields.Default, base_type=fields.Default, **kwargs):
         super().__init__(string=string, _base_type=base_type, **kwargs)
 
     def _setup_attrs(self, model, name):
         super()._setup_attrs(model, name)
-        if not self._base_type_default_json():
+        if self._base_type not in self._default_json_mapping:
             raise ValueError("%s is not a supported base type" % (self._base_type))
 
-    def _base_type_default_json(self):
-        return self._default_json_mapping.get(self._base_type)
+    def _base_type_default_json(self, env):
+        default_json = self._default_json_mapping.get(self._base_type)
+        if not isinstance(default_json, str):
+            default_json = default_json(env)
+        return default_json
 
     def convert_to_column(self, value, record, values=None, validate=True):
         return self.convert_to_cache(value, record, validate=validate)
@@ -51,7 +62,7 @@ class JobSerialized(fields.Field):
             return value or None
 
     def convert_to_record(self, value, record):
-        default = self._base_type_default_json()
+        default = self._base_type_default_json(record.env)
         return json.loads(value or default, cls=JobDecoder, env=record.env)
 
 
@@ -97,6 +108,7 @@ class JobDecoder(json.JSONDecoder):
             model = self.env[obj["model"]]
             if obj.get("uid"):
                 model = model.with_user(obj["uid"])
+
             return model.browse(obj["ids"])
         elif type_ == "datetime_isoformat":
             return dateutil.parser.parse(obj["value"])

--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -76,6 +76,7 @@ class JobEncoder(json.JSONEncoder):
                 "model": obj._name,
                 "ids": obj.ids,
                 "uid": obj.env.uid,
+                "su": obj.env.su,
             }
         elif isinstance(obj, datetime):
             return {"_type": "datetime_isoformat", "value": obj.isoformat()}
@@ -105,9 +106,7 @@ class JobDecoder(json.JSONDecoder):
             return obj
         type_ = obj["_type"]
         if type_ == "odoo_recordset":
-            model = self.env[obj["model"]]
-            if obj.get("uid"):
-                model = model.with_user(obj["uid"])
+            model = self.env(user=obj.get("uid"), su=obj.get("su"))[obj["model"]]
 
             return model.browse(obj["ids"])
         elif type_ == "datetime_isoformat":

--- a/queue_job/i18n/queue_job.pot
+++ b/queue_job/i18n/queue_job.pot
@@ -544,8 +544,8 @@ msgid "Queue jobs must created by calling 'with_delay()'."
 msgstr ""
 
 #. module: queue_job
-#: model:ir.model.fields,field_description:queue_job.field_queue_job__record_ids
-msgid "Record"
+#: model:ir.model.fields,field_description:queue_job.field_queue_job__records
+msgid "Record(s)"
 msgstr ""
 
 #. module: queue_job

--- a/queue_job/migrations/13.0.3.2.0/pre-migration.py
+++ b/queue_job/migrations/13.0.3.2.0/pre-migration.py
@@ -1,0 +1,28 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+
+from odoo.tools.sql import column_exists
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not column_exists(cr, "queue_job", "records"):
+        cr.execute(
+            """
+            ALTER TABLE queue_job
+            ADD COLUMN records text;
+        """
+        )
+    cr.execute(
+        """
+    UPDATE queue_job
+    SET records = '{"_type": "odoo_recordset"'
+    || ', "model": "' || model_name || '"'
+    || ', "uid": ' || user_id
+    || ', "ids": ' || record_ids
+    || '}'
+    WHERE records IS NULL;
+    """
+    )

--- a/queue_job/readme/USAGE.rst
+++ b/queue_job/readme/USAGE.rst
@@ -80,7 +80,7 @@ Example of related action code:
         def related_action_partner(self, name):
             self.ensure_one()
             model = self.model_name
-            partner = self.env[model].browse(self.record_ids)
+            partner = self.records
             action = {
                 'name': name,
                 'type': 'ir.actions.act_window',

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -24,6 +24,7 @@ class TestJson(common.TransactionCase):
             "_type": "odoo_recordset",
             "model": "res.partner",
             "ids": [partner.id],
+            "su": False,
         }
         self.assertEqual(json.loads(value_json), expected)
 
@@ -40,6 +41,7 @@ class TestJson(common.TransactionCase):
                 "_type": "odoo_recordset",
                 "model": "res.partner",
                 "ids": [partner.id],
+                "su": False,
             },
         ]
         self.assertEqual(json.loads(value_json), expected)
@@ -50,6 +52,7 @@ class TestJson(common.TransactionCase):
         value_json = (
             '{"_type": "odoo_recordset",'
             '"model": "res.partner",'
+            '"su": false,'
             '"ids": [%s],"uid": %s}' % (partner.id, demo_user.id)
         )
         expected = partner
@@ -64,6 +67,7 @@ class TestJson(common.TransactionCase):
             '["a", 1, '
             '{"_type": "odoo_recordset",'
             '"model": "res.partner",'
+            '"su": false,'
             '"ids": [%s],"uid": %s}]' % (partner.id, demo_user.id)
         )
         expected = ["a", 1, partner]

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -17,6 +17,19 @@ class TestJson(common.TransactionCase):
     def test_encoder_recordset(self):
         demo_user = self.env.ref("base.user_demo")
         partner = self.env(user=demo_user).ref("base.main_partner")
+        value = partner
+        value_json = json.dumps(value, cls=JobEncoder)
+        expected = {
+            "uid": demo_user.id,
+            "_type": "odoo_recordset",
+            "model": "res.partner",
+            "ids": [partner.id],
+        }
+        self.assertEqual(json.loads(value_json), expected)
+
+    def test_encoder_recordset_list(self):
+        demo_user = self.env.ref("base.user_demo")
+        partner = self.env(user=demo_user).ref("base.main_partner")
         value = ["a", 1, partner]
         value_json = json.dumps(value, cls=JobEncoder)
         expected = [
@@ -35,6 +48,19 @@ class TestJson(common.TransactionCase):
         demo_user = self.env.ref("base.user_demo")
         partner = self.env(user=demo_user).ref("base.main_partner")
         value_json = (
+            '{"_type": "odoo_recordset",'
+            '"model": "res.partner",'
+            '"ids": [%s],"uid": %s}' % (partner.id, demo_user.id)
+        )
+        expected = partner
+        value = json.loads(value_json, cls=JobDecoder, env=self.env)
+        self.assertEqual(value, expected)
+        self.assertEqual(demo_user, expected.env.user)
+
+    def test_decoder_recordset_list(self):
+        demo_user = self.env.ref("base.user_demo")
+        partner = self.env(user=demo_user).ref("base.main_partner")
+        value_json = (
             '["a", 1, '
             '{"_type": "odoo_recordset",'
             '"model": "res.partner",'
@@ -45,7 +71,7 @@ class TestJson(common.TransactionCase):
         self.assertEqual(value, expected)
         self.assertEqual(demo_user, expected[2].env.user)
 
-    def test_decoder_recordset_without_user(self):
+    def test_decoder_recordset_list_without_user(self):
         value_json = (
             '["a", 1, {"_type": "odoo_recordset",' '"model": "res.users", "ids": [1]}]'
         )

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -193,7 +193,6 @@ class TestJobsOnTestingMethod(JobCommonCase):
             eta=eta,
             description="My description",
         )
-        test_job.user_id = 1
         test_job.worker_pid = 99999  # normally set on "set_start"
         test_job.company_id = self.env.ref("base.main_company").id
         test_job.store()
@@ -252,7 +251,6 @@ class TestJobsOnTestingMethod(JobCommonCase):
             priority=15,
             description=u"My dé^Wdescription",
         )
-        test_job.user_id = 1
         test_job.store()
         job_read = Job.load(self.env, test_job.uuid)
         self.assertEqual(test_job.args, job_read.args)
@@ -270,7 +268,6 @@ class TestJobsOnTestingMethod(JobCommonCase):
             priority=15,
             description="My dé^Wdescription",
         )
-        test_job.user_id = 1
         test_job.store()
         job_read = Job.load(self.env, test_job.uuid)
         self.assertEqual(job_read.args, ("öô¿‽", "ñě"))
@@ -300,7 +297,6 @@ class TestJobsOnTestingMethod(JobCommonCase):
             description="Test I am the first one",
             identity_key=id_key,
         )
-        test_job_1.user_id = 1
         test_job_1.store()
         job1 = Job.load(self.env, test_job_1.uuid)
         self.assertEqual(job1.identity_key, id_key)
@@ -506,6 +502,12 @@ class TestJobModel(JobCommonCase):
         delayable = self.env["test.queue.job"].with_delay(channel="root.sub.sub")
         test_job = delayable.testing_method(return_context=True)
         self.assertEqual("root.sub.sub", test_job.channel)
+
+    def test_job_change_user_id(self):
+        demo_user = self.env.ref("base.user_demo")
+        stored = self._create_job()
+        stored.user_id = demo_user
+        self.assertEqual(stored.records.env.uid, demo_user.id)
 
 
 class TestJobStorageMultiCompany(common.TransactionCase):


### PR DESCRIPTION
Replaces #272 

Previously, the "main" record, the one on which the job works, was stored in 3 fields: `model_name`, `user_id` and `record_ids` (and the support for any new field such as sudo or context would need a new field). The records of `args` and `kwargs` are serialized in `JobSerialized` fields.

This PR unifies the way they are stored: the "main" record is now stored in a `JobSerialized` field as well.
The support of the `su` flag (which means the record was `sudo()`-ed), is added in the second commit, which shows how we benefit from the refactor.

The original fields are kept:

* `model_name` is stored for the UI (used in search or groupby)
* `user_id` is stored for the same reason, but also has a `inverse` method that updates the serialized record
* `record_ids` is kept only for backward compatibility, but could be removed in 14.0