### PR TITLE
[13.0] Fix required sudo in Job

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -377,7 +377,7 @@ class Job(object):
     def db_record_from_uuid(env, job_uuid):
         model = env["queue.job"].sudo()
         record = model.search([("uuid", "=", job_uuid)], limit=1)
-        return record.with_env(env)
+        return record.with_env(env).sudo()
 
     def __init__(
         self,


### PR DESCRIPTION
Following changes of #281
The initial sudo() is lost when we call "with_env()" with a False su
flag. Ensure the read job.record keeps a su flag.