### PR TITLE
Fix required sudo in Job

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -558,7 +558,7 @@ class Job(object):
 
         db_record = self.db_record()
         if db_record:
-            db_record.with_context(_job_edit_sentinel=edit_sentinel).write(vals)
+            db_record.with_context(_job_edit_sentinel=edit_sentinel).sudo().write(vals)
         else:
             date_created = self.date_created
             # The following values must never be modified after the


### PR DESCRIPTION
Fix the infinite loop:
odoo.exceptions.AccessError: ("Sorry, you are not allowed to access documents of type 'Queue Job' (queue.job). This operation is allowed for the groups:\n\t- Job Queue/Job Queue Manager - (Operation: read, User: 5679)", None) - - -