### PR TITLE
[13.0][FIX] run doctests as part of standard tests

### DIFF
--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import channels
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(channels))
-    return tests
+load_tests = load_doctests(channels)

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import runner
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(runner))
-    return tests
+load_tests = load_doctests(runner)


### PR DESCRIPTION
Odoo v12 introduced [test tags](https://github.com/odoo/odoo/commit/b356b190338e3ee032b9e3a7f670f76468965006).

Since then doctests were not running anymore.

This PR introduces a wrapper for `doctest.DocTestCase` to get doctests to run again as part of standard tests.