### PR TITLE
[10.0][FIX] Mail notification with sudo

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -3,7 +3,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '10.0.1.2.0',
+ 'version': '10.0.1.2.1',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue',
  'license': 'LGPL-3',

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -199,8 +199,9 @@ class QueueJob(models.Model):
         for record in self:
             msg = record._message_failed_job()
             if msg:
-                record.message_post(body=msg,
-                                    subtype='queue_job.mt_job_failed')
+                record.sudo().message_post(
+                    body=msg,
+                    subtype='queue_job.mt_job_failed')
 
     @api.multi
     def write(self, vals):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -190,20 +190,23 @@ class QueueJob(models.Model):
         self._change_job_state(PENDING)
         return True
 
+    def _message_post_on_failure(self):
+        # subscribe the users now to avoid to subscribe them
+        # at every job creation
+        domain = self._subscribe_users_domain()
+        users = self.env['res.users'].search(domain)
+        self.message_subscribe_users(user_ids=users.ids)
+        for record in self:
+            msg = record._message_failed_job()
+            if msg:
+                record.message_post(body=msg,
+                                    subtype='queue_job.mt_job_failed')
+
     @api.multi
     def write(self, vals):
         res = super(QueueJob, self).write(vals)
         if vals.get('state') == 'failed':
-            # subscribe the users now to avoid to subscribe them
-            # at every job creation
-            domain = self._subscribe_users_domain()
-            users = self.env['res.users'].search(domain)
-            self.message_subscribe_users(user_ids=users.ids)
-            for record in self:
-                msg = record._message_failed_job()
-                if msg:
-                    record.message_post(body=msg,
-                                        subtype='queue_job.mt_job_failed')
+            self._message_post_on_failure()
         return res
 
     @api.multi

--- a/queue_job/readme/HISTORY.rst
+++ b/queue_job/readme/HISTORY.rst
@@ -17,6 +17,12 @@ Next
   the job is linked to respectively one record on several).
   (`#79 <https://github.com/OCA/queue/pull/79>`_, backport from `#46 <https://github.com/OCA/queue/pull/46>`_)
 
+10.0.1.1.3
+~~~~~~~~~~
+
+* [REF] Extract a method handling the post of a message when a job is failed,
+  allowing to modify this behavior from addons (Backport of `#108 <https://github.com/OCA/queue/pull/108>`)
+
 10.0.1.0.0
 ~~~~~~~~~~
 


### PR DESCRIPTION
Sometimes the mail notification fails because the user triggering the queue does not have rights on the mail.notification record.
