### PR TITLE
[14.0] queue_job: ensure order of compute complete_name

### DIFF
--- a/queue_job/models/queue_job_channel.py
+++ b/queue_job/models/queue_job_channel.py
@@ -35,6 +35,10 @@ class QueueJobChannel(models.Model):
             if not record.name:
                 complete_name = ""  # new record
             elif record.parent_id:
+                if not record.parent_id.complete_name:
+                    # self is not sorted, parent_id.complete_name
+                    # is may be not computed yet
+                    record.parent_id._compute_complete_name()
                 complete_name = ".".join([record.parent_id.complete_name, record.name])
             else:
                 complete_name = record.name


### PR DESCRIPTION
`record.parent_id.complete_name` can be `False`.
I guess it's because self is not oriented by `.parent_id` so the child is complete_name is computed before the parent.

With this fix, some records can be computed twice. I guess it's ok.

Discovered while installing module (shopinvader_import_product). Got errors during the load of xml views.
