### PR TITLE
[13.0] Remove initial create notification and follower

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -186,7 +186,10 @@ class QueueJob(models.Model):
             raise exceptions.AccessError(
                 _("Queue jobs must created by calling 'with_delay()'.")
             )
-        return super().create(vals_list)
+        return super(
+            QueueJob,
+            self.with_context(mail_create_nolog=True, mail_create_nosubscribe=True),
+        ).create(vals_list)
 
     def write(self, vals):
         if self.env.context.get("_job_edit_sentinel") is not self.EDIT_SENTINEL:
@@ -243,9 +246,10 @@ class QueueJob(models.Model):
         # subscribe the users now to avoid to subscribe them
         # at every job creation
         domain = self._subscribe_users_domain()
-        users = self.env["res.users"].search(domain)
-        self.message_subscribe(partner_ids=users.mapped("partner_id").ids)
+        base_users = self.env["res.users"].search(domain)
         for record in self:
+            users = base_users | record.user_id
+            record.message_subscribe(partner_ids=users.mapped("partner_id").ids)
             msg = record._message_failed_job()
             if msg:
                 record.message_post(body=msg, subtype="queue_job.mt_job_failed")


### PR DESCRIPTION
Everytime a job is created, a mail.message "Queue Job created" is
created. This is useless, as we already have the creation date and user,
and nobody will ever want to receive a notification for a created job
anyway.

Removing the auto-subscription of the user that created the job makes
sense as well since we automatically subscribe the queue job managers
for failures, and we don't send other notifications.

It allows to remove a lot of insertions of records (and of deletions
when autovacuuming jobs).

Rough benchmark when generating jobs for ddmrp buffers (it includes some base
time to fetch the ddmrp buffers too). 9191 jobs were created:

executed with | duration
-------------------|------------
no optimizations | 2m18s
create optimization (#305) | 1m41s
mail.message/follower optimization (current PR) | 1m11s
both optimizations | 35s
