### PR TITLE
[13.0] [FIX] queue_job: create/replace queue_job_notify function at migration

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Job Queue",
-    "version": "13.0.3.3.0",
+    "version": "13.0.3.3.1",
     "author": "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/queue/queue_job",
     "license": "LGPL-3",

--- a/queue_job/migrations/13.0.3.3.1/post-migration.py
+++ b/queue_job/migrations/13.0.3.3.1/post-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.queue_job.hooks.post_init_hook import post_init_hook
+
+
+def migrate(cr, version):
+    post_init_hook(cr, None)


### PR DESCRIPTION
This step seems necessary on migrated databases (9.0 -> 13.0).
The code is taken from the post init hook.