### PR TITLE
[12.0] Fix missing rollback on retried jobs

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -594,6 +594,7 @@ class Job(object):
         self.state = PENDING
         self.date_enqueued = None
         self.date_started = None
+        self.date_done = None
         if reset_retry:
             self.retry = 0
         if result is not None:


### PR DESCRIPTION
When RetryableJobError was raised, any change done by the job was not
rollbacked.

Using raise would throw the exception up to the core and rollback, but
we would have a stack trace in the logs for each try. Calling rollback
manually (rollback also clears the env) hide the tracebacks, however,
when the last try fails, the full traceback is still shown in the logs.

Fixes #261