### PR TITLE
[13.0] Fix missing rollback on retried jobs

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -77,10 +77,10 @@ class RunJobController(http.Controller):
                 if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
                     raise
 
-                retry_postpone(
-                    job, tools.ustr(err.pgerror, errors="replace"), seconds=PG_RETRY
-                )
                 _logger.debug("%s OperationalError, postponed", job)
+                raise RetryableJobError(
+                    tools.ustr(err.pgerror, errors="replace"), seconds=PG_RETRY
+                )
 
         except NothingToDoJob as err:
             if str(err):
@@ -95,6 +95,10 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, str(err), seconds=err.seconds)
             _logger.debug("%s postponed", job)
+            # Do not trigger the error up because we don't want an exception
+            # traceback in the logs we should have the traceback when all
+            # retries are exhausted
+            env.cr.rollback()
 
         except (FailedJobError, Exception):
             buff = StringIO()

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -665,6 +665,7 @@ class Job(object):
         self.state = PENDING
         self.date_enqueued = None
         self.date_started = None
+        self.date_done = None
         self.worker_pid = None
         if reset_retry:
             self.retry = 0


### PR DESCRIPTION
Port from #284 / #311

When RetryableJobError was raised, any change done by the job was not
rollbacked.

Using `raise` would throw the exception up to the core and rollback, but
we would have a stack trace in the logs for each try. Calling rollback
manually (rollback also clears the env) hide the tracebacks, however,
when the last try fails, the full traceback is still shown in the logs.

Fixes #261