### PR TITLE
[10.0][FIX] queue_job: drop trigger when rewriting table in migration

### DIFF
--- a/queue_job/migrations/10.0.1.0.0/post-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/post-migration.py
@@ -5,11 +5,13 @@
 
 def migrate(cr, version):
     """Extract from old `func_name` field the name of the method to be put
-    on `method_name`.
+    on `method_name`. Drop notify trigger for drastically better performance.
     """
     if not version:
         return
     cr.execute(
-        """UPDATE queue_job
+        """
+        DROP TRIGGER IF EXISTS queue_job_notify ON queue_job;
+        UPDATE queue_job
         SET method_name = reverse(split_part(reverse(func_name), '.', 1))"""
     )


### PR DESCRIPTION
On a large table, the migration query takes 23 seconds after dropping the
trigger (before that, it took 8 minutes).

```
                                                         QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------
 Update on queue_job  (cost=0.00..55301.11 rows=238578 width=1409) (actual time=22486.104..22486.105 rows=0 loops=1)
   ->  Seq Scan on queue_job  (cost=0.00..55301.11 rows=238578 width=1409) (actual time=0.015..415.132 rows=237130 loops=1)
 Planning Time: 0.080 ms
 Trigger queue_job_notify: time=457262.118 calls=237130
 Execution Time: 479831.502 ms
(5 rows)
```