### PR TITLE
[IMP] [14.0] store job execution data on execution

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -18,6 +18,7 @@
         "views/queue_job_function_views.xml",
         "wizards/queue_jobs_to_done_views.xml",
         "wizards/queue_requeue_job_views.xml",
+        "wizards/queue_terminate_job_views.xml",
         "views/queue_job_menus.xml",
         "data/queue_data.xml",
         "data/queue_job_function_data.xml",

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -8,7 +8,7 @@ from odoo import _, api, exceptions, fields, models
 from odoo.osv import expression
 
 from ..fields import JobSerialized
-from ..job import DONE, PENDING, STATES, Job
+from ..job import DONE, PENDING, STARTED, STATES, Job
 
 _logger = logging.getLogger(__name__)
 
@@ -236,6 +236,32 @@ class QueueJob(models.Model):
     def requeue(self):
         self._change_job_state(PENDING)
         return True
+
+    def terminate(self):
+        """Attempt to kill the backend process related to the running job."""
+        error_jobs = self.env["queue.job"]
+        for record in self:
+            # Check if the job can be terminated
+            if record.state != STARTED:
+                _logger.warning(
+                    "Unable to terminate job %s because it is not started",
+                    record.uuid
+                )
+                error_jobs += record
+                continue
+            elif not record.db_backend_pid:
+                _logger.warning(
+                    "Unable to terminate job %s. Missing 'db_backend_pid' value",
+                    record.uuid
+                )
+                error_jobs += record
+                continue
+
+            # Terminate the backend
+            query_vals = {"pid": record.db_backend_pid}
+            self.env.cr.execute("SELECT pg_terminate_backend(%(pid)s);", query_vals)
+
+        return error_jobs
 
     def _message_post_on_failure(self):
         # subscribe the users now to avoid to subscribe them

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -109,6 +109,8 @@ class QueueJob(models.Model):
 
     identity_key = fields.Char()
     worker_pid = fields.Integer()
+    worker_hostname = fields.Char()
+    db_backend_pid = fields.Integer()
 
     def init(self):
         self._cr.execute(

--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -8,6 +8,14 @@
             <form string="Jobs" create="false" delete="false">
                 <header>
                     <button
+                        name="terminate"
+                        states="started"
+                        class="oe_highlight"
+                        string="Terminate Job"
+                        type="object"
+                        groups="queue_job.group_queue_job_manager"
+                    />
+                    <button
                         name="requeue"
                         states="failed"
                         class="oe_highlight"

--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -51,6 +51,8 @@
                             />
                             <field name="user_id" />
                             <field name="worker_pid" groups="base.group_no_one" />
+                            <field name="worker_hostname" groups="base.groups_no_one"/>
+                            <field name="db_backend_pid" groups="base.groups_no_one"/>
                         </group>
                         <group>
                             <field name="date_created" />

--- a/queue_job/wizards/__init__.py
+++ b/queue_job/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import queue_requeue_job
 from . import queue_jobs_to_done
+from . import queue_terminate_job

--- a/queue_job/wizards/queue_terminate_job.py
+++ b/queue_job/wizards/queue_terminate_job.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2020 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+
+class QueueTerminateJob(models.TransientModel):
+    _name = "queue.terminate.job"
+    _description = "Wizard to terminate a job"
+
+    def _default_job_ids(self):
+        res = False
+        context = self.env.context
+        if context.get("active_model") == "queue.job" and context.get("active_ids"):
+            res = context["active_ids"]
+        return res
+
+    job_ids = fields.Many2many(
+        comodel_name="queue.job", string="Jobs", default=lambda r: r._default_job_ids()
+    )
+
+    def terminate(self):
+        failed = self.job_ids.terminate()
+        if failed:
+            raise UserError(
+                "Failed to terminate the following jobs:%s" %
+                "\n- ".join(failed.mapped("uuid"))
+            )
+        return {"type": "ir.actions.act_window_close"}

--- a/queue_job/wizards/queue_terminate_job_views.xml
+++ b/queue_job/wizards/queue_terminate_job_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="queue_terminate_job_view_form" model="ir.ui.view">
+        <field name="name">Terminate Jobs</field>
+        <field name="model">queue.terminate.job</field>
+        <field name="arch" type="xml">
+            <form string="Terminate Jobs">
+                <group string="The selected jobs will be terminated.">
+                    <field name="job_ids" nolabel="1" />
+                </group>
+                <footer>
+                    <button
+                        name="terminate"
+                        string="Terminate"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="queue_terminate_job_action" model="ir.actions.act_window">
+        <field name="name">Terminate Jobs</field>
+        <field name="res_model">queue.terminate.job</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="queue_terminate_job_view_form" />
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="queue_job.model_queue_job" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
This adds functionality to store the name of the host on which the job is executed.
Also store the DB Backend PID as reference.

Primary motivation: Be able to kill either the Odoo process or the backend process in case of issues.