### PR TITLE
[REF] Replace deprecated assertEquals with assertEqual

### DIFF
--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -97,8 +97,8 @@ class TestJobsOnTestingMethod(JobCommonCase):
 
     def test_on_model_method(self):
         job_ = Job(self.env["test.queue.job"].testing_method)
-        self.assertEquals(job_.model_name, "test.queue.job")
-        self.assertEquals(job_.method_name, "testing_method")
+        self.assertEqual(job_.model_name, "test.queue.job")
+        self.assertEqual(job_.method_name, "testing_method")
 
     def test_invalid_function(self):
         with self.assertRaises(TypeError):
@@ -107,11 +107,11 @@ class TestJobsOnTestingMethod(JobCommonCase):
     def test_set_pending(self):
         job_a = Job(self.method)
         job_a.set_pending(result="test")
-        self.assertEquals(job_a.state, PENDING)
+        self.assertEqual(job_a.state, PENDING)
         self.assertFalse(job_a.date_enqueued)
         self.assertFalse(job_a.date_started)
-        self.assertEquals(job_a.retry, 0)
-        self.assertEquals(job_a.result, "test")
+        self.assertEqual(job_a.retry, 0)
+        self.assertEqual(job_a.result, "test")
 
     def test_set_enqueued(self):
         job_a = Job(self.method)
@@ -120,8 +120,8 @@ class TestJobsOnTestingMethod(JobCommonCase):
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_enqueued()
 
-        self.assertEquals(job_a.state, ENQUEUED)
-        self.assertEquals(job_a.date_enqueued, datetime(2015, 3, 15, 16, 41, 0))
+        self.assertEqual(job_a.state, ENQUEUED)
+        self.assertEqual(job_a.date_enqueued, datetime(2015, 3, 15, 16, 41, 0))
         self.assertFalse(job_a.date_started)
 
     def test_set_started(self):
@@ -131,8 +131,8 @@ class TestJobsOnTestingMethod(JobCommonCase):
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_started()
 
-        self.assertEquals(job_a.state, STARTED)
-        self.assertEquals(job_a.date_started, datetime(2015, 3, 15, 16, 41, 0))
+        self.assertEqual(job_a.state, STARTED)
+        self.assertEqual(job_a.date_started, datetime(2015, 3, 15, 16, 41, 0))
 
     def test_worker_pid(self):
         """When a job is started, it gets the PID of the worker that starts it"""
@@ -155,16 +155,16 @@ class TestJobsOnTestingMethod(JobCommonCase):
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.set_done(result="test")
 
-        self.assertEquals(job_a.state, DONE)
-        self.assertEquals(job_a.result, "test")
-        self.assertEquals(job_a.date_done, datetime(2015, 3, 15, 16, 41, 0))
+        self.assertEqual(job_a.state, DONE)
+        self.assertEqual(job_a.result, "test")
+        self.assertEqual(job_a.date_done, datetime(2015, 3, 15, 16, 41, 0))
         self.assertFalse(job_a.exc_info)
 
     def test_set_failed(self):
         job_a = Job(self.method)
         job_a.set_failed(exc_info="failed test")
-        self.assertEquals(job_a.state, FAILED)
-        self.assertEquals(job_a.exc_info, "failed test")
+        self.assertEqual(job_a.state, FAILED)
+        self.assertEqual(job_a.exc_info, "failed test")
 
     def test_postpone(self):
         job_a = Job(self.method)
@@ -173,8 +173,8 @@ class TestJobsOnTestingMethod(JobCommonCase):
             mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
             job_a.postpone(result="test", seconds=60)
 
-        self.assertEquals(job_a.eta, datetime(2015, 3, 15, 16, 42, 0))
-        self.assertEquals(job_a.result, "test")
+        self.assertEqual(job_a.eta, datetime(2015, 3, 15, 16, 42, 0))
+        self.assertEqual(job_a.result, "test")
         self.assertFalse(job_a.exc_info)
 
     def test_store(self):
@@ -287,7 +287,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         job_instance = delayable.testing_method("a", k=1)
         self.assertTrue(job_instance)
         result = job_instance.perform()
-        self.assertEquals(result, (("a",), {"k": 1}))
+        self.assertEqual(result, (("a",), {"k": 1}))
 
     def test_job_identity_key_str(self):
         id_key = "e294e8444453b09d59bdb6efbfec1323"
@@ -393,11 +393,11 @@ class TestJobs(JobCommonCase):
         recs = rec1 + rec2
         job_instance = recs.with_delay().mapped("name")
         self.assertTrue(job_instance)
-        self.assertEquals(job_instance.args, ("name",))
-        self.assertEquals(job_instance.recordset, recs)
-        self.assertEquals(job_instance.model_name, "test.queue.job")
-        self.assertEquals(job_instance.method_name, "mapped")
-        self.assertEquals(["test1", "test2"], job_instance.perform())
+        self.assertEqual(job_instance.args, ("name",))
+        self.assertEqual(job_instance.recordset, recs)
+        self.assertEqual(job_instance.model_name, "test.queue.job")
+        self.assertEqual(job_instance.method_name, "mapped")
+        self.assertEqual(["test1", "test2"], job_instance.perform())
 
     def test_job_identity_key_no_duplicate(self):
         """ If a job with same identity key in queue do not add a new one """
@@ -415,7 +415,7 @@ class TestJobs(JobCommonCase):
         job_instance = delayable.job_alter_mutable([1], mutable_kwarg={"a": 1})
         self.assertTrue(job_instance)
         result = job_instance.perform()
-        self.assertEquals(result, ([1, 2], {"a": 1, "b": 2}))
+        self.assertEqual(result, ([1, 2], {"a": 1, "b": 2}))
         job_instance.set_done()
         # at this point, the 'args' and 'kwargs' of the job instance
         # might have been modified, but they must never be modified in
@@ -425,8 +425,8 @@ class TestJobs(JobCommonCase):
         # jobs are always loaded before being performed, so we simulate
         # this behavior here to check if we have the correct initial arguments
         job_instance = Job.load(self.env, job_instance.uuid)
-        self.assertEquals(([1],), job_instance.args)
-        self.assertEquals({"mutable_kwarg": {"a": 1}}, job_instance.kwargs)
+        self.assertEqual(([1],), job_instance.args)
+        self.assertEqual({"mutable_kwarg": {"a": 1}}, job_instance.kwargs)
 
     def test_store_env_su_no_sudo(self):
         demo_user = self.env.ref("base.user_demo")

--- a/test_queue_job/tests/test_job_channels.py
+++ b/test_queue_job/tests/test_job_channels.py
@@ -22,8 +22,8 @@ class TestJobChannels(common.TransactionCase):
         subchannel = self.channel_model.create(
             {"name": "five", "parent_id": channel.id}
         )
-        self.assertEquals(channel.complete_name, "root.number")
-        self.assertEquals(subchannel.complete_name, "root.number.five")
+        self.assertEqual(channel.complete_name, "root.number")
+        self.assertEqual(subchannel.complete_name, "root.number.five")
 
     def test_channel_tree(self):
         with self.assertRaises(exceptions.ValidationError):
@@ -42,14 +42,14 @@ class TestJobChannels(common.TransactionCase):
         )
         job_func = self.function_model.search([("name", "=", path_a)])
 
-        self.assertEquals(job_func.channel, "root")
+        self.assertEqual(job_func.channel, "root")
 
         test_job = Job(method)
         test_job.store()
         stored = test_job.db_record()
-        self.assertEquals(stored.channel, "root")
+        self.assertEqual(stored.channel, "root")
         job_read = Job.load(self.env, test_job.uuid)
-        self.assertEquals(job_read.channel, "root")
+        self.assertEqual(job_read.channel, "root")
 
         sub_channel = self.env.ref("test_queue_job.channel_sub")
         job_func.channel_id = sub_channel
@@ -57,20 +57,20 @@ class TestJobChannels(common.TransactionCase):
         test_job = Job(method)
         test_job.store()
         stored = test_job.db_record()
-        self.assertEquals(stored.channel, "root.sub")
+        self.assertEqual(stored.channel, "root.sub")
 
         # it's also possible to override the channel
         test_job = Job(method, channel="root.sub")
         test_job.store()
         stored = test_job.db_record()
-        self.assertEquals(stored.channel, test_job.channel)
+        self.assertEqual(stored.channel, test_job.channel)
 
     def test_default_channel_no_xml(self):
         """Channel on job is root if there is no queue.job.function record"""
         test_job = Job(self.env["res.users"].browse)
         test_job.store()
         stored = test_job.db_record()
-        self.assertEquals(stored.channel, "root")
+        self.assertEqual(stored.channel, "root")
 
     def test_set_channel_from_record(self):
         func_name = self.env["queue.job.function"].job_function_name(
@@ -80,10 +80,10 @@ class TestJobChannels(common.TransactionCase):
         self.assertEqual(job_func.channel, "root.sub.subsub")
 
         channel = job_func.channel_id
-        self.assertEquals(channel.name, "subsub")
-        self.assertEquals(channel.parent_id.name, "sub")
-        self.assertEquals(channel.parent_id.parent_id.name, "root")
-        self.assertEquals(job_func.channel, "root.sub.subsub")
+        self.assertEqual(channel.name, "subsub")
+        self.assertEqual(channel.parent_id.name, "sub")
+        self.assertEqual(channel.parent_id.parent_id.name, "root")
+        self.assertEqual(job_func.channel, "root.sub.subsub")
 
     def test_default_removal_interval(self):
         channel = self.channel_model.create(

--- a/test_queue_job/tests/test_related_actions.py
+++ b/test_queue_job/tests/test_related_actions.py
@@ -48,7 +48,7 @@ class TestRelatedAction(common.SavepointCase):
         """
         job_ = self.model.with_delay().testing_related_action__no()
         expected = None
-        self.assertEquals(job_.related_action(), expected)
+        self.assertEqual(job_.related_action(), expected)
 
     def test_model_default_no_record(self):
         """Model shows an error when using the default action and we have no
@@ -74,7 +74,7 @@ class TestRelatedAction(common.SavepointCase):
             "type": "ir.actions.act_window",
             "view_mode": "form",
         }
-        self.assertEquals(job_.related_action(), expected)
+        self.assertEqual(job_.related_action(), expected)
 
     def test_default_several_record(self):
         """Default related action called when no decorator is set
@@ -91,7 +91,7 @@ class TestRelatedAction(common.SavepointCase):
             "type": "ir.actions.act_window",
             "view_mode": "tree,form",
         }
-        self.assertEquals(job_.related_action(), expected)
+        self.assertEqual(job_.related_action(), expected)
 
     def test_decorator(self):
         """Call the related action on the model
@@ -111,4 +111,4 @@ class TestRelatedAction(common.SavepointCase):
             "target": "new",
             "url": "https://en.wikipedia.org/wiki/Discworld",
         }
-        self.assertEquals(job_.related_action(), expected)
+        self.assertEqual(job_.related_action(), expected)


### PR DESCRIPTION
`assertEquals` has been deprecated https://docs.python.org/3/library/unittest.html#deprecated-aliases