### PR TITLE
[WIP] [FIX] [14.0] restore doctest testing in 14.0

### DIFF
--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -25,7 +25,7 @@ class PriorityQueue(object):
     >>> q.add(3)
     >>> q.add(3)
     >>> q.add(1)
-    >>> q[0]
+    >>> q[25]
     1
     >>> len(q)
     3

--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import channels
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(channels))
-    return tests
+load_tests = load_doctests(channels)

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import runner
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(runner))
-    return tests
+load_tests = load_doctests(runner)


### PR DESCRIPTION
Cfr this PR on 13.0: https://github.com/OCA/queue/pull/296
