### PR TITLE
[FIX] 14.0 doctests hidden errors

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -1,10 +1,14 @@
 # Copyright 2019 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import doctest
 from contextlib import contextmanager
 
 import mock
 
-from ..job import Job
+from odoo.tests import BaseCase, tagged
+
+# pylint: disable=odoo-addons-relative-import
+from odoo.addons.queue_job.job import Job
 
 
 class JobCounter:
@@ -96,3 +100,37 @@ def mock_with_delay():
         delayable = mock.MagicMock(name="DelayableBinding")
         delayable_cls.return_value = delayable
         yield delayable_cls, delayable
+
+
+@tagged("doctest")
+class OdooDocTestCase(BaseCase):
+    """
+    We need a custom DocTestCase class in order to:
+    - define test_tags to run as part of standard tests
+    - output a more meaningful test name than default "DocTestCase.runTest"
+    """
+
+    __qualname__ = "doctests for "
+
+    def __init__(self, test):
+        self.__test = test
+        self.__name = test._dt_test.name
+        super().__init__(self.__name)
+
+    def __getattr__(self, item):
+        if item == self.__name:
+            return self.__test
+
+
+def load_doctests(module):
+    """
+    Generates a tests loading method for the doctests of the given module
+    https://docs.python.org/3/library/unittest.html#load-tests-protocol
+    """
+
+    def load_tests(loader, tests, ignore):
+        for test in doctest.DocTestSuite(module):
+            tests.addTest(OdooDocTestCase(test))
+        return tests
+
+    return load_tests

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -5,8 +5,6 @@ from contextlib import contextmanager
 
 import mock
 
-from odoo.tests import BaseCase, tagged
-
 # pylint: disable=odoo-addons-relative-import
 from odoo.addons.queue_job.job import Job
 
@@ -102,26 +100,6 @@ def mock_with_delay():
         yield delayable_cls, delayable
 
 
-@tagged("doctest")
-class OdooDocTestCase(BaseCase):
-    """
-    We need a custom DocTestCase class in order to:
-    - define test_tags to run as part of standard tests
-    - output a more meaningful test name than default "DocTestCase.runTest"
-    """
-
-    __qualname__ = "doctests for "
-
-    def __init__(self, test):
-        self.__test = test
-        self.__name = test._dt_test.name
-        super().__init__(self.__name)
-
-    def __getattr__(self, item):
-        if item == self.__name:
-            return self.__test
-
-
 def load_doctests(module):
     """
     Generates a tests loading method for the doctests of the given module
@@ -129,8 +107,12 @@ def load_doctests(module):
     """
 
     def load_tests(loader, tests, ignore):
-        for test in doctest.DocTestSuite(module):
-            tests.addTest(OdooDocTestCase(test))
+        """
+        Apply the 'test_tags' attribute to each DocTestCase found by the DocTestSuite
+        """
+        tests.addTests(doctest.DocTestSuite(module))
+        for test in tests:
+            test.test_tags = {"standard", "at_install", "queue_job", "doctests"}
         return tests
 
     return load_tests

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import doctest
+import sys
 from contextlib import contextmanager
 
 import mock
@@ -108,8 +109,13 @@ def load_doctests(module):
 
     def load_tests(loader, tests, ignore):
         """
-        Apply the 'test_tags' attribute to each DocTestCase found by the DocTestSuite
+        Apply the 'test_tags' attribute to each DocTestCase found by the DocTestSuite.
+        Also extend the DocTestCase class trivially to fit the class teardown
+        that Odoo backported for its own test classes from Python 3.8.
         """
+        if sys.version_info < (3, 8):
+            doctest.DocTestCase.doClassCleanups = lambda: None
+            doctest.DocTestCase.tearDown_exceptions = []
         tests.addTests(doctest.DocTestSuite(module))
         for test in tests:
             test.test_tags = {"standard", "at_install", "queue_job", "doctests"}

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -7,8 +7,7 @@ from contextlib import contextmanager
 
 import mock
 
-# pylint: disable=odoo-addons-relative-import
-from odoo.addons.queue_job.job import Job
+from ..job import Job
 
 
 class JobCounter:

--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import channels
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(channels))
-    return tests
+load_tests = load_doctests(channels)

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -1,13 +1,10 @@
 # Copyright 2015-2016 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import doctest
-
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
 from odoo.addons.queue_job.jobrunner import runner
 
+from .common import load_doctests
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(runner))
-    return tests
+load_tests = load_doctests(runner)


### PR DESCRIPTION
At the moment, a doctest that fails is not registered in the output of the test results.
I have tested this hypothesis here: https://github.com/OCA/queue/pull/336 where the tests do not fail, even though there is a clear error present!