### PR TITLE
[14.0][FIX] queue_job: replace deprecated use of logging.warn

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -57,7 +57,7 @@ class RunJobController(http.Controller):
             (job_uuid, ENQUEUED),
         )
         if not env.cr.fetchone():
-            _logger.warn(
+            _logger.warning(
                 "was requested to run job %s, but it does not exist, "
                 "or is not in state %s",
                 job_uuid,

--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -79,10 +79,14 @@ class Base(models.AbstractModel):
             @mute_logger('odoo.addons.queue_job.models.base')
         """
         if os.getenv("TEST_QUEUE_JOB_NO_DELAY"):
-            _logger.warn("`TEST_QUEUE_JOB_NO_DELAY` env var found. NO JOB scheduled.")
+            _logger.warning(
+                "`TEST_QUEUE_JOB_NO_DELAY` env var found. NO JOB scheduled."
+            )
             return self
         if self.env.context.get("test_queue_job_no_delay"):
-            _logger.warn("`test_queue_job_no_delay` ctx key found. NO JOB scheduled.")
+            _logger.warning(
+                "`test_queue_job_no_delay` ctx key found. NO JOB scheduled."
+            )
             return self
         return DelayableRecordset(
             self,


### PR DESCRIPTION
Use of logging.warn is deprecated since python3.4 and causes a deprecation warning in the odoo log if using python 3.8.

https://docs.python.org/3/library/logging.html#logging.Logger.warning