### PR TITLE
[10.0][IMP] queue_job: migrate args and kwargs from func column

### DIFF
--- a/queue_job/migrations/10.0.1.0.0/end-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/end-migration.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 from odoo import api, SUPERUSER_ID
+from odoo.addons.queue_job.job import DONE
 
 
 def migrate(cr, version):
@@ -28,3 +29,8 @@ def migrate(cr, version):
                     method.im_class._name, method.__name__,
                 ),
             })
+    # recompute func_string after other addons have adapted their
+    # args/kwargs/record_ids
+    records = QueueJob.search([('state', 'not in', [DONE])])
+    records._recompute_todo(QueueJob._fields['func_string'])
+    records.recompute()

--- a/queue_job/migrations/10.0.1.0.0/post-migration.py
+++ b/queue_job/migrations/10.0.1.0.0/post-migration.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+import json
+import logging
+from cPickle import Unpickler
+from StringIO import StringIO
+from odoo.addons.queue_job.job import DONE
+from odoo.addons.queue_job.fields import JobEncoder
+
+
+_logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
@@ -15,3 +24,30 @@ def migrate(cr, version):
         UPDATE queue_job
         SET method_name = reverse(split_part(reverse(func_name), '.', 1))"""
     )
+    migrate_args_kwargs(cr)
+
+
+def migrate_args_kwargs(cr):
+    """Extract args and kwargs from v9 func column, which is the tuple
+    (func_name, args, kwargs) pickled in a binary string. Ignore done
+    jobs for performance reasons"""
+    cr.execute(
+        'select id, func from queue_job where state not in %s',
+        (tuple([DONE]),),
+    )
+    for _id, func in cr.fetchall():
+        try:
+            func_name, args, kwargs = Unpickler(StringIO(func)).load()
+        except Exception:
+            _logger.exception(
+                'Failed to parse func column for queue_job#%s', _id,
+            )
+            continue
+        cr.execute(
+            'update queue_job set args=%s, kwargs=%s where id=%s',
+            (
+                json.dumps(args, cls=JobEncoder),
+                json.dumps(kwargs, cls=JobEncoder),
+                _id,
+            ),
+        )


### PR DESCRIPTION
this in itself isn't sufficient for any job, but other migrations can use the parsed args/kwargs to simplify their own migrations