### PR TITLE
[12.0][FIX] missing attachment type

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -100,7 +100,8 @@ class BaseImportImport(models.TransientModel):
         attachment = self.env['ir.attachment'].create({
             'name': file_name,
             'datas': datas,
-            'datas_fname': file_name
+            'datas_fname': file_name,
+            'type': 'binary',
         })
         return attachment
 


### PR DESCRIPTION
When importing `product.template` with `Import in the background` set, `ir.attachment` `type` field is guessed? as `product`, which is invalid.

![Screenshot(10)](https://user-images.githubusercontent.com/7657311/117812269-e21c2800-b261-11eb-8be6-bf56be076918.png)
