### PR TITLE
[13.0] Fix display on exec_time on tree view as seconds

### DIFF
--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -114,7 +114,7 @@
                 <field name="date_created" />
                 <field name="eta" />
                 <field name="date_done" />
-                <field name="exec_time" widget="float_time" />
+                <field name="exec_time" />
                 <field name="exc_name" />
                 <field name="exc_message" />
                 <field name="uuid" />


### PR DESCRIPTION
The float_time widget shows hours seconds, we only want seconds.
The widget had been removed on the form view, but not on the tree view.