### PR TITLE
[13.0][FIX] queue_job_cron: channel_id must be storable.

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -17,13 +17,16 @@ class IrCron(models.Model):
         comodel_name="queue.job.channel",
         compute="_compute_run_as_queue_job",
         readonly=False,
+        store=True,
         string="Channel",
     )
 
     @api.depends("run_as_queue_job")
     def _compute_run_as_queue_job(self):
         for cron in self:
-            if cron.run_as_queue_job and not cron.channel_id:
+            if cron.channel_id:
+                continue
+            if cron.run_as_queue_job:
                 cron.channel_id = self.env.ref("queue_job_cron.channel_root_ir_cron").id
             else:
                 cron.channel_id = False


### PR DESCRIPTION
Otherwise, you cannot use any channel other than default (
root.ir_cron)

The struggle was real without this fix :cry:  :
![Peek 2021-06-11 16-13](https://user-images.githubusercontent.com/23449160/121701247-fe192080-cad0-11eb-83ef-bf120a48dd8c.gif)

After the fix life is great :smile:  :
![Peek 2021-06-11 16-19](https://user-images.githubusercontent.com/23449160/121701274-05d8c500-cad1-11eb-8c11-9391c26bd020.gif)

@ForgeFlow
