### PR TITLE
[FIX] queue_job: Migrations raising errors

### DIFF
--- a/queue_job/migrations/13.0.3.2.0/pre-migration.py
+++ b/queue_job/migrations/13.0.3.2.0/pre-migration.py
@@ -2,12 +2,14 @@
 
 import logging
 
-from odoo.tools.sql import column_exists
+from odoo.tools.sql import column_exists, table_exists
 
 _logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
+    if not table_exists(cr, "queue_job"):
+        return
     if not column_exists(cr, "queue_job", "records"):
         cr.execute(
             """

--- a/queue_job/migrations/13.0.3.7.0/pre-migration.py
+++ b/queue_job/migrations/13.0.3.7.0/pre-migration.py
@@ -2,13 +2,15 @@
 
 import logging
 
-from odoo.tools.sql import column_exists
+from odoo.tools.sql import column_exists, table_exists
 
 _logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
-    if not column_exists(cr, "queue_job", "exec_time"):
+    if table_exists(cr, "queue_job") and not column_exists(
+        cr, "queue_job", "exec_time"
+    ):
         # Disable trigger otherwise the update takes ages.
         cr.execute(
             """


### PR DESCRIPTION
When executing OpenUpgrade with a database that didn't have queue_job but a module change on 13.0 required it, several errors where raised (I don't know why, but OpenUpgrade executed the migrations). In order to solve them, I had to change the scripts applying this changes