### PR TITLE
[12.0] Fix field channel_method_name is not computed

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -100,11 +100,9 @@ class QueueJob(models.Model):
              "max. retries.\n"
              "Retries are infinite when empty.",
     )
-    # FIXME the name of this field is very confusing
 
-    channel_method_name = fields.Char(readonly=True,
-                                      compute='_compute_job_function',
-                                      store=True)
+    # FIXME the name of this field is very confusing
+    channel_method_name = fields.Char(readonly=True)
     job_function_id = fields.Many2one(comodel_name='queue.job.function',
                                       string='Job Function',
                                       readonly=True)


### PR DESCRIPTION
The field has been changed to a normal stored field in ad20a1e, (https://github.com/OCA/queue/commit/bb88d1efcd9da47591c915d770c4af7f84315aa5 in 13.0).
it should not have a computed attribute.