### PR TITLE
[IMP] no need for base_sparse_field anymore since 0f5ec1

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -7,9 +7,7 @@
  'website': 'https://github.com/OCA/queue/tree/12.0/queue_job',
  'license': 'LGPL-3',
  'category': 'Generic Modules',
- 'depends': ['mail',
-             'base_sparse_field'
-             ],
+ 'depends': ['mail'],
  'external_dependencies': {'python': ['requests'
                                       ],
                            },


### PR DESCRIPTION
- Since https://github.com/oca/queue/commit/0f5ec1 `Serialized` fields have been replaced by `JobSerialized` fields
- No need for forward ports, as this dependency has been removed already in further versions