### PR TITLE
[DOC][14.0] describe how to write queue.job.function in case of function defined in abstract model

### DIFF
--- a/queue_job/readme/USAGE.rst
+++ b/queue_job/readme/USAGE.rst
@@ -43,6 +43,13 @@ they have different xmlids. On uninstall, the merged record is deleted when all
 the modules using it are uninstalled.
 
 
+**Job function: model**
+
+If the function is defined in an abstract model, you can not write
+``<field name="model_id" ref="xml_id_of_the_abstract_model"</field>``
+but you have to define a function for each model that inherits from the abstract model.
+
+
 **Job function: channel**
 
 The channel where the job will be delayed. The default channel is ``root``.


### PR DESCRIPTION
**Context**

- having an abstract model (mixin) with a function to be delayed.
- inherit in many models.

**Expected behaviour**
- write a ``queue.job.function`` with the abstract model should work and catch the correct channel.

**Current behaviour**
- we have to write a queue.job.function per model. Otherwise, the match is not done, and job is affected to root channel.

This PR just explicits the current behaviour of ``queue_job`` module. 

CC : FYI, @guewen


Note : I have the problem in V12, but i think more relevant to fix the doc upstream)
