### PR TITLE
[13.0][IMP] queue_job current company

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,7 +628,15 @@ class Job(object):
 
     @property
     def func(self):
-        recordset = self.recordset.with_context(job_uuid=self.uuid)
+        user = self.env["res.users"].browse(self.user_id)
+        company_ids = user.company_ids.ids
+        # Insert the current company in top position
+        company_ids.insert(0, self.company_id)
+        # Remove duplicates but keep order
+        company_ids = list(dict.fromkeys(company_ids))
+        recordset = self.recordset.with_context(
+            job_uuid=self.uuid, allowed_company_ids=company_ids
+        )
         return getattr(recordset, self.method_name)
 
     @property

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,12 +628,13 @@ class Job(object):
 
     @property
     def func(self):
-        user = self.env["res.users"].browse(self.user_id)
-        company_ids = user.company_ids.ids
-        # Insert the current company in top position
-        company_ids.insert(0, self.company_id)
-        # Remove duplicates but keep order
-        company_ids = list(dict.fromkeys(company_ids))
+        # We can fill only one company into allowed_company_ids.
+        # Because if you have many, you can have unexpected records due to ir.rule.
+        # ir.rule use allowed_company_ids to load every records in many companies.
+        # But most of the time, a job should be executed on a single company.
+        company_ids = []
+        if self.company_id:
+            company_ids = [self.company_id]
         recordset = self.recordset.with_context(
             job_uuid=self.uuid, allowed_company_ids=company_ids
         )

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -241,9 +241,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         job_read = Job.load(self.env, test_job.uuid)
         self.assertEqual(test_job.func, job_read.func)
         result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
-        self.assertEqual(
-            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
-        )
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company2.ids)
 
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -200,6 +200,51 @@ class TestJobsOnTestingMethod(JobCommonCase):
         stored.invalidate_cache()
         self.assertEqual(stored.additional_info, "JUST_TESTING_BUT_FAILED")
 
+    def test_company_simple(self):
+        company = self.env.ref("base.main_company")
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company.ids)
+
+    def test_company_complex(self):
+        company1 = self.env.ref("base.main_company")
+        company2 = company1.create({"name": "Queue job company"})
+        companies = company1 | company2
+        self.env.user.write({"company_ids": [(6, False, companies.ids)]})
+        # Ensure the main company still the first
+        self.assertEqual(self.env.user.company_id, company1)
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company2.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(
+            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
+        )
+
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)
         test_job = Job(


### PR DESCRIPTION
I currently have some trouble to trigger `job` because they use the default company of the user instead of the active one.
I see this open discussion: https://github.com/OCA/queue/issues/363 but IMO using a serialized context is not in opposition with this solution as the key `allowed_company_ids` is not always in the context (only if the user switch company?).

I did 2 commits (IMO it's important to keep them):
1) Force companies into the context (via `allowed_company_ids` key)
2) Only load the job's company into `allowed_company_ids` because it could load too many unexpected records (during search).