### PR TITLE
[13.0] Vacuum done jobs in batch

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -254,11 +254,19 @@ class QueueJob(models.Model):
         """
         for channel in self.env["queue.job.channel"].search([]):
             deadline = datetime.now() - timedelta(days=int(channel.removal_interval))
-            jobs = self.search(
-                [("date_done", "<=", deadline), ("channel", "=", channel.complete_name)]
-            )
-            if jobs:
-                jobs.unlink()
+            while True:
+                jobs = self.search(
+                    [
+                        ("date_done", "<=", deadline),
+                        ("channel", "=", channel.complete_name),
+                    ],
+                    limit=1000,
+                )
+                if jobs:
+                    jobs.unlink()
+                    self.env.cr.commit()
+                else:
+                    break
         return True
 
     def requeue_stuck_jobs(self, enqueued_delta=5, started_delta=0):


### PR DESCRIPTION
Huge amount of jobs to delete may take a lot of time and the cron may crash, because of timeout for instance
This issue would make the cron permanently run and permanently failing... Deleting batch allow to avoid this issue
if the cron fails, it still will have delete some of the job history

This is just a cherry-pick from #313. The same problem affects `13.0` as well.