### PR TITLE
[12.0] FIX queue_job avoiding AccessDenied when loading the module in an instance with list_db = False

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -391,7 +391,7 @@ class QueueJobRunner(object):
         if config['db_name']:
             db_names = config['db_name'].split(',')
         else:
-            db_names = odoo.service.db.exp_list(True)
+            db_names = odoo.service.db.list_dbs(True)
         return db_names
 
     def close_databases(self, remove_jobs=True):


### PR DESCRIPTION
The scenario is a multi database environment where you can't set db_name as the databases change frequently and you use dbfilter to allow users to access their DB according to domain

Also see https://github.com/OCA/queue/issues/58