### PR TITLE
 [FIX] queue_job : check if queue_job_notify exist in pre-migration script to avoid error when migrating from 10.0 revision

### DIFF
--- a/queue_job/migrations/12.0.1.0.1/post-migration.py
+++ b/queue_job/migrations/12.0.1.0.1/post-migration.py
@@ -3,7 +3,6 @@
 # License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
 
 import odoo
-from odoo.addons.queue_job.hooks.post_init_hook import post_init_hook
 
 
 def migrate(cr, version):
@@ -17,5 +16,3 @@ def migrate(cr, version):
             raise_if_not_found=False)
         if cron_job and cron_job.exists() and cron_job.state != 'code':
             cron_job.state = 'code'
-    # Ensure that the queue_job_notify trigger is in place
-    post_init_hook(cr, None)

--- a/queue_job/migrations/12.0.1.0.1/pre-migration.py
+++ b/queue_job/migrations/12.0.1.0.1/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Versada UAB
+# Copyright 2021 ACSONE SA/NV
+# License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.queue_job.hooks.post_init_hook import post_init_hook
+
+
+def migrate(cr, version):
+    # Ensure that the queue_job_notify trigger is in place
+    post_init_hook(cr, None)

--- a/queue_job/migrations/12.0.2.1.0/pre-migration.py
+++ b/queue_job/migrations/12.0.2.1.0/pre-migration.py
@@ -8,6 +8,12 @@ _logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
+    # Disable trigger otherwise the update takes ages.
+    cr.execute(
+        """
+        ALTER TABLE queue_job DISABLE TRIGGER queue_job_notify;
+    """
+    )
     if not column_exists(cr, "queue_job", "records"):
         cr.execute(
             """
@@ -24,5 +30,10 @@ def migrate(cr, version):
     || ', "ids": ' || record_ids
     || '}'
     WHERE records IS NULL;
+    """
+    )
+    cr.execute(
+        """
+        ALTER TABLE queue_job ENABLE TRIGGER queue_job_notify;
     """
     )


### PR DESCRIPTION
Hi,

**Context**

- upgrade ``queue_job`` module from version < 12.0. (in my case 10.0)
- the database doesn't have the trigger ``queue_job_notify`` on the table ``queue_job``.

**Rational**
- For the time being, the post-migration ``12.0.1.0.1/post-migration.py`` check if the trigger exist, and if not, create it. (via ``post_init_hook`` function)
- the pre-migration script ``12.0.2.2.0/pre-migration.py`` consider that the trigger exist and disable it. (and enable it after...)

The problem is that **all the pre-migration scripts** are executed before **all the post migration scripts**.
So the pre-migration script ``12.0.2.2.0`` is executed before the trigger is created.

The problem is present since #333 has been merged. CC : authors and reviewers : @etobella, @StefanRijnhart, @simahawk, @guewen

**Solution**
- create the trigger in a pre-migration script.

**Log after the PR**

```
INFO odoo.modules.migration: module queue_job: Running migration [>12.0.1.0.1] pre-migration
INFO odoo.addons.queue_job.hooks.post_init_hook: Create queue_job_notify trigger
INFO odoo.modules.migration: module queue_job: Running migration [>12.0.2.1.0] pre-migration
INFO odoo.modules.migration: module queue_job: Running migration [>12.0.2.2.0] pre-migration
INFO odoo.modules.registry: module queue_job: creating or updating database tables
INFO odoo.models: Actual recompute of field ir.model.fields.related_field_id for 34 recs.
INFO odoo.models: Actual recompute of field ir.model.fields.relation_field_id for 33 recs.
INFO odoo.modules.loading: loading queue_job/security/security.xml
INFO odoo.models: Actual recompute of field res.users.share for 1 recs.
INFO odoo.models: Actual recompute of field res.partner.partner_share for 1 recs.
INFO odoo.modules.loading: loading queue_job/security/ir.model.access.csv
INFO odoo.modules.loading: loading queue_job/views/queue_job_views.xml
INFO odoo.modules.loading: loading queue_job/data/queue_data.xml
INFO odoo.models: Actual recompute of field queue.job.channel.complete_name for 1 recs.
INFO odoo.models: Actual recompute of field queue.job.channel.complete_name for 3 recs.
INFO odoo.models: Actual recompute of field queue.job.function.channel for 8 recs.
INFO odoo.modules.loading: loading queue_job/data/queue_job_function_data.xml
INFO odoo.models: Actual recompute of field queue.job.function.channel for 1 recs.
INFO odoo.models: Actual recompute of field queue.job.function.name for 1 recs.
INFO odoo.modules.migration: module queue_job: Running migration [12.0.1.0.1>] post-migration
INFO odoo.modules.migration: module queue_job: Running migration [12.0.2.0.0>] post-migration
INFO odoo.modules.migration: module queue_job: Running migration [12.0.2.3.0>] post-migration
INFO post-migration: Computing exception name for failed jobs
```