### PR TITLE
[14.0][FIX] queue_job_cron: channel_id must be storable.

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -17,13 +17,16 @@ class IrCron(models.Model):
         comodel_name="queue.job.channel",
         compute="_compute_run_as_queue_job",
         readonly=False,
+        store=True,
         string="Channel",
     )
 
     @api.depends("run_as_queue_job")
     def _compute_run_as_queue_job(self):
         for cron in self:
-            if cron.run_as_queue_job and not cron.channel_id:
+            if cron.channel_id:
+                continue
+            if cron.run_as_queue_job:
                 cron.channel_id = self.env.ref("queue_job_cron.channel_root_ir_cron").id
             else:
                 cron.channel_id = False


### PR DESCRIPTION
forward port https://github.com/OCA/queue/pull/355