### PR TITLE
[13.0][IMP] queue_job: use context to execute job (optional)

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,7 +628,15 @@ class Job(object):
 
     @property
     def func(self):
-        recordset = self.recordset.with_context(job_uuid=self.uuid)
+        user = self.env["res.users"].browse(self.user_id)
+        company_ids = user.company_ids.ids
+        # Insert the current company in top position
+        company_ids.insert(0, self.company_id)
+        # Remove duplicates but keep order
+        company_ids = list(dict.fromkeys(company_ids))
+        recordset = self.recordset.with_context(
+            job_uuid=self.uuid, allowed_company_ids=company_ids
+        )
         return getattr(recordset, self.method_name)
 
     @property

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,12 +628,13 @@ class Job(object):
 
     @property
     def func(self):
-        user = self.env["res.users"].browse(self.user_id)
-        company_ids = user.company_ids.ids
-        # Insert the current company in top position
-        company_ids.insert(0, self.company_id)
-        # Remove duplicates but keep order
-        company_ids = list(dict.fromkeys(company_ids))
+        # We can fill only one company into allowed_company_ids.
+        # Because if you have many, you can have unexpected records due to ir.rule.
+        # ir.rule use allowed_company_ids to load every records in many companies.
+        # But most of the time, a job should be executed on a single company.
+        company_ids = []
+        if self.company_id:
+            company_ids = [self.company_id]
         recordset = self.recordset.with_context(
             job_uuid=self.uuid, allowed_company_ids=company_ids
         )

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -59,6 +59,7 @@ class DelayableRecordset(object):
         description=None,
         channel=None,
         identity_key=None,
+        keep_context=False,
     ):
         self.recordset = recordset
         self.priority = priority
@@ -67,6 +68,7 @@ class DelayableRecordset(object):
         self.description = description
         self.channel = channel
         self.identity_key = identity_key
+        self.keep_context = keep_context
 
     def __getattr__(self, name):
         if name in self.recordset:
@@ -88,6 +90,7 @@ class DelayableRecordset(object):
                 description=self.description,
                 channel=self.channel,
                 identity_key=self.identity_key,
+                keep_context=self.keep_context,
             )
 
         return delay
@@ -339,6 +342,7 @@ class Job(object):
         description=None,
         channel=None,
         identity_key=None,
+        keep_context=False,
     ):
         """Create a Job and enqueue it in the queue. Return the job uuid.
 
@@ -359,6 +363,7 @@ class Job(object):
             description=description,
             channel=channel,
             identity_key=identity_key,
+            keep_context=keep_context,
         )
         if new_job.identity_key:
             existing = new_job.job_record_with_same_identity_key()
@@ -399,6 +404,7 @@ class Job(object):
         description=None,
         channel=None,
         identity_key=None,
+        keep_context=False,
     ):
         """ Create a Job
 
@@ -423,8 +429,11 @@ class Job(object):
         :param identity_key: A hash to uniquely identify a job, or a function
                              that returns this hash (the function takes the job
                              as argument)
-        :param env: Odoo Environment
-        :type env: :class:`odoo.api.Environment`
+        :param keep_context: Determine if the current context should be restored.
+                             Set to True to keep entire context.
+                             Possibility to provide a list of keys to keep
+                             from the current context.
+        :type keep_context: :bool or list
         """
         if args is None:
             args = ()
@@ -445,6 +454,7 @@ class Job(object):
         self.recordset = recordset
 
         self.env = env
+        self.keep_context = keep_context
         self.job_model = self.env["queue.job"]
         self.job_model_name = "queue.job"
 
@@ -591,11 +601,19 @@ class Job(object):
                     "method_name": self.method_name,
                     "job_function_id": self.job_config.job_function_id,
                     "channel_method_name": self.job_function_name,
-                    "records": self.recordset,
                     "args": self.args,
                     "kwargs": self.kwargs,
                 }
             )
+            # By default the context is completely reset
+            # (compatibility with previous version).
+            context = {}
+            if self.keep_context:
+                context = self.env.context.copy()
+                if isinstance(self.keep_context, list):
+                    context = {k: context.get(k) for k in self.keep_context}
+            recordset = self.recordset.with_context(context)
+            vals.update({"records": recordset})
 
         vals_from_model = self._store_values_from_model()
         # Sanitize values: make sure you cannot screw core values
@@ -615,6 +633,17 @@ class Job(object):
                 vals = handler(self)
         return vals
 
+    def _get_record_context(self):
+        """
+        Get the context to execute the job
+        """
+        context = {}
+        company_ids = []
+        if self.company_id:
+            company_ids = [self.company_id]
+        context.update({"job_uuid": self.uuid, "allowed_company_ids": company_ids})
+        return context
+
     @property
     def func_string(self):
         model = repr(self.recordset)
@@ -628,16 +657,8 @@ class Job(object):
 
     @property
     def func(self):
-        # We can fill only one company into allowed_company_ids.
-        # Because if you have many, you can have unexpected records due to ir.rule.
-        # ir.rule use allowed_company_ids to load every records in many companies.
-        # But most of the time, a job should be executed on a single company.
-        company_ids = []
-        if self.company_id:
-            company_ids = [self.company_id]
-        recordset = self.recordset.with_context(
-            job_uuid=self.uuid, allowed_company_ids=company_ids
-        )
+        context = self._get_record_context()
+        recordset = self.recordset.with_context(**context)
         return getattr(recordset, self.method_name)
 
     @property

--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -44,6 +44,7 @@ class Base(models.AbstractModel):
         description=None,
         channel=None,
         identity_key=None,
+        keep_context=True,
     ):
         """ Return a ``DelayableRecordset``
 
@@ -81,6 +82,8 @@ class Base(models.AbstractModel):
                              the new job will not be added. It is either a
                              string, either a function that takes the job as
                              argument (see :py:func:`..job.identity_exact`).
+        :param keep_context: boolean to set if the current context
+                             should be restored on the recordset (default: True).
         :return: instance of a DelayableRecordset
         :rtype: :class:`odoo.addons.queue_job.job.DelayableRecordset`
 
@@ -108,6 +111,7 @@ class Base(models.AbstractModel):
             description=description,
             channel=channel,
             identity_key=identity_key,
+            keep_context=keep_context,
         )
 
     def _patch_job_auto_delay(self, method_name, context_key=None):

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -25,6 +25,7 @@ class TestJson(common.TransactionCase):
             "model": "res.partner",
             "ids": [partner.id],
             "su": False,
+            "context": {},
         }
         self.assertEqual(json.loads(value_json), expected)
 
@@ -42,6 +43,7 @@ class TestJson(common.TransactionCase):
                 "model": "res.partner",
                 "ids": [partner.id],
                 "su": False,
+                "context": {},
             },
         ]
         self.assertEqual(json.loads(value_json), expected)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -241,9 +241,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         job_read = Job.load(self.env, test_job.uuid)
         self.assertEqual(test_job.func, job_read.func)
         result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
-        self.assertEqual(
-            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
-        )
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company2.ids)
 
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -200,6 +200,51 @@ class TestJobsOnTestingMethod(JobCommonCase):
         stored.invalidate_cache()
         self.assertEqual(stored.additional_info, "JUST_TESTING_BUT_FAILED")
 
+    def test_company_simple(self):
+        company = self.env.ref("base.main_company")
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company.ids)
+
+    def test_company_complex(self):
+        company1 = self.env.ref("base.main_company")
+        company2 = company1.create({"name": "Queue job company"})
+        companies = company1 | company2
+        self.env.user.write({"company_ids": [(6, False, companies.ids)]})
+        # Ensure the main company still the first
+        self.assertEqual(self.env.user.company_id, company1)
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company2.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(
+            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
+        )
+
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)
         test_job = Job(


### PR DESCRIPTION
In some case, we need to keep the context to execute the job.
On the `with_delay(...)`, add a parameter `keep_context` (default `True`) to know if the context should be saved on the job.
The `keep_context` parameter could be:
- `False`: do not use `context`;
- `True`(default value): use full `context`;
- `list` of key: keep only given keys into the `context`.

Je context is saved on the `JobEncoder` and then restored with `JobDecoder`.

Depends on https://github.com/OCA/queue/pull/365 (about company)