### PR TITLE
[13.0][FIX] base_import_async - User's lang is ignored

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -59,7 +59,9 @@ class BaseImportImport(models.TransientModel):
         attachment = self._create_csv_attachment(
             import_fields, data, options, self.file_name
         )
-        delayed_job = self.with_delay(description=description)._split_file(
+        delayed_job = self.with_delay(
+            description=description, keep_context=True
+        )._split_file(
             model_name=self.res_model,
             translated_model_name=translated_model_name,
             attachment=attachment,
@@ -162,7 +164,7 @@ class BaseImportImport(models.TransientModel):
                 file_name=root + "-" + chunk + ext,
             )
             delayed_job = self.with_delay(
-                description=description, priority=priority
+                description=description, priority=priority, keep_context=True
             )._import_one_chunk(
                 model_name=model_name, attachment=attachment, options=options
             )

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,7 +628,15 @@ class Job(object):
 
     @property
     def func(self):
-        recordset = self.recordset.with_context(job_uuid=self.uuid)
+        user = self.env["res.users"].browse(self.user_id)
+        company_ids = user.company_ids.ids
+        # Insert the current company in top position
+        company_ids.insert(0, self.company_id)
+        # Remove duplicates but keep order
+        company_ids = list(dict.fromkeys(company_ids))
+        recordset = self.recordset.with_context(
+            job_uuid=self.uuid, allowed_company_ids=company_ids
+        )
         return getattr(recordset, self.method_name)
 
     @property

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -628,12 +628,13 @@ class Job(object):
 
     @property
     def func(self):
-        user = self.env["res.users"].browse(self.user_id)
-        company_ids = user.company_ids.ids
-        # Insert the current company in top position
-        company_ids.insert(0, self.company_id)
-        # Remove duplicates but keep order
-        company_ids = list(dict.fromkeys(company_ids))
+        # We can fill only one company into allowed_company_ids.
+        # Because if you have many, you can have unexpected records due to ir.rule.
+        # ir.rule use allowed_company_ids to load every records in many companies.
+        # But most of the time, a job should be executed on a single company.
+        company_ids = []
+        if self.company_id:
+            company_ids = [self.company_id]
         recordset = self.recordset.with_context(
             job_uuid=self.uuid, allowed_company_ids=company_ids
         )

--- a/queue_job/models/base.py
+++ b/queue_job/models/base.py
@@ -44,6 +44,7 @@ class Base(models.AbstractModel):
         description=None,
         channel=None,
         identity_key=None,
+        keep_context=False,
     ):
         """ Return a ``DelayableRecordset``
 
@@ -81,6 +82,8 @@ class Base(models.AbstractModel):
                              the new job will not be added. It is either a
                              string, either a function that takes the job as
                              argument (see :py:func:`..job.identity_exact`).
+        :param keep_context: boolean to set if the current context
+                             should be restored on the recordset (default: False).
         :return: instance of a DelayableRecordset
         :rtype: :class:`odoo.addons.queue_job.job.DelayableRecordset`
 
@@ -108,6 +111,7 @@ class Base(models.AbstractModel):
             description=description,
             channel=channel,
             identity_key=identity_key,
+            keep_context=keep_context,
         )
 
     def _patch_job_auto_delay(self, method_name, context_key=None):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -57,6 +57,12 @@ class QueueJob(models.Model):
         comodel_name="res.company", string="Company", index=True
     )
     name = fields.Char(string="Description", readonly=True)
+    context = fields.Char(
+        string="Context Value",
+        default="{}",
+        help="Context dictionary as Python expression, empty by default (Default: {})",
+        readonly=True,
+    )
 
     model_name = fields.Char(string="Model", readonly=True)
     method_name = fields.Char(readonly=True)

--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -60,6 +60,9 @@
                             <field name="exec_time" string="Time (s)" />
                         </group>
                     </group>
+                    <group name="context_grp">
+                        <field name="context" />
+                    </group>
                     <group colspan="4">
                         <div>
                             <label for="retry" string="Current try / max. retries" />

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -241,9 +241,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         job_read = Job.load(self.env, test_job.uuid)
         self.assertEqual(test_job.func, job_read.func)
         result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
-        self.assertEqual(
-            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
-        )
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company2.ids)
 
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -200,6 +200,51 @@ class TestJobsOnTestingMethod(JobCommonCase):
         stored.invalidate_cache()
         self.assertEqual(stored.additional_info, "JUST_TESTING_BUT_FAILED")
 
+    def test_company_simple(self):
+        company = self.env.ref("base.main_company")
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(result_ctx.get("allowed_company_ids"), company.ids)
+
+    def test_company_complex(self):
+        company1 = self.env.ref("base.main_company")
+        company2 = company1.create({"name": "Queue job company"})
+        companies = company1 | company2
+        self.env.user.write({"company_ids": [(6, False, companies.ids)]})
+        # Ensure the main company still the first
+        self.assertEqual(self.env.user.company_id, company1)
+        eta = datetime.now() + timedelta(hours=5)
+        test_job = Job(
+            self.method,
+            args=("o", "k"),
+            kwargs={"return_context": 1},
+            priority=15,
+            eta=eta,
+            description="My description",
+        )
+        test_job.worker_pid = 99999  # normally set on "set_start"
+        test_job.company_id = company2.id
+        test_job.store()
+        job_read = Job.load(self.env, test_job.uuid)
+        self.assertEqual(test_job.func, job_read.func)
+        result_ctx = test_job.func(*tuple(test_job.args), **test_job.kwargs)
+        self.assertEqual(
+            result_ctx.get("allowed_company_ids"), [company2.id, company1.id]
+        )
+
     def test_read(self):
         eta = datetime.now() + timedelta(hours=5)
         test_job = Job(


### PR DESCRIPTION
Keep context during import.
In some case, the lang set into the context is important to do the import.
For example when the file contain a translatable name as a key (ex: product.attribute) and currently as there is no context, the search is executed in English (default lang) instead of user's lang.


Depends on https://github.com/OCA/queue/pull/406