### PR TITLE
[RFC] jobrunner cli

### DIFF
--- a/queue_job/jobrunner/__main__.py
+++ b/queue_job/jobrunner/__main__.py
@@ -1,0 +1,13 @@
+import odoo
+
+from .runner import QueueJobRunner
+
+
+def main():
+    odoo.tools.config.parse_config()
+    runner = QueueJobRunner.from_environ_or_config()
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
~/!\ This is very rough and mostly untested. So just an idea so far.~

I wonder if running the job runner in a standalone process could be a solution to the problem of running a single job runner in a multi-node deployment.

We could then let the responsibility of running one replica of the job runner to the orchestrator (say, k8s), and we don't need ensure it's a singleton ourselves.

Use with `env ODOO_RC=odoo.cfg python -m odoo.addons.queue_job.jobrunner`.