### PR TITLE
[14.0] queue_job: use parent channel if configured

### DIFF
--- a/queue_job/readme/CONTRIBUTORS.rst
+++ b/queue_job/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Tatiana Deribina <tatiana.deribina@avoin.systems>
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 * Eric Antones <eantones@nuobit.com>
+* Simone Orsi <simone.orsi@camptocamp.com>


### PR DESCRIPTION
Use case:

* you have a root channel per scope/app (eg: root.edi)
* you have several sub channels (eg: root.edi.ubl.sales,
root.edi.gs1.delivery)
* you want to configure capacity only for the main channel "root.edi"

Before this change, the channel manager falls back on root channel,
and you get flooded w/ warning log entries like "unknown channel....".

However, if you have a specific parent channel configured
it sounds a good idea to use it.

NOTE: using `parent_fallback` flag is just an attempt to not break places where this feat is not desiderable.
Also, I might fail to see why this behavior was not supported before: any remark is welcomed :)

@guewen can I have your insights please? :pray: 