### PR TITLE
[14.0][FIX] queue_job: support for multi-db environments

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -35,6 +35,7 @@ How to use it?
     or ``False`` if unset.
   - ``ODOO_QUEUE_JOB_JOBRUNNER_DB_PORT=5432``, default ``db_port``
     or ``False`` if unset.
+  - ``ODOO_QUEUE_JOB_JOBRUNNER_DB_NAME=firstdb,seconddb``, default ``db_name``
 
 * Alternatively, configure the channels through the Odoo configuration
   file, like:
@@ -50,6 +51,7 @@ How to use it?
   http_auth_password = s3cr3t
   jobrunner_db_host = master-db
   jobrunner_db_port = 5432
+  jobrunner_db_name = firstdb,seconddb
 
 * Or, if using ``anybox.recipe.odoo``, add this to your buildout configuration:
 
@@ -390,7 +392,11 @@ class QueueJobRunner(object):
         return runner
 
     def get_db_names(self):
-        if config["db_name"]:
+        if os.environ.get("ODOO_QUEUE_JOB_JOBRUNNER_DB_NAME"):
+            db_names = os.environ["ODOO_QUEUE_JOB_JOBRUNNER_DB_NAME"].split(",")
+        elif queue_job_config.get("jobrunner_db_name"):
+            db_names = queue_job_config["jobrunner_db_name"].split(",")
+        elif config["db_name"]:
             db_names = config["db_name"].split(",")
         else:
             db_names = odoo.service.db.exp_list(True)


### PR DESCRIPTION
This change improves functionality in environments with multiple databases in the postgres cluster. Some environments have hidden databases, and may use list_db = False in favor of the db_filter config parameter. In these cases, exp_list will return an AccessError. Or, some environments may have multiple databases used by multiple instances of Odoo, managed by a load balancer. It's possible that not all DBs will have the queue_job module installed. Sometimes, we will want the job runner to work on a limited set of DBs.

This change adds the option of an environment variable, ODOO_QUEUE_JOB_DB_NAME, or a config parameter in the [queue] section, jobrunner_db_name. This takes a comma separated list of DB names, just like db_name does. If the variable/parameter is not set, it defaults to db_name (the previous functionality). 

Related:
#379 - Another fix for 12.0, solves the same problem when list_db=False
#58  - This resolves the issue