### PR TITLE
[IMP] queue_job: Recover gracefully when the CPU limit is reached

### DIFF
--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -54,6 +54,7 @@ class WorkerJobRunner(server.Worker):
         super(WorkerJobRunner, self).__init__(multi)
         self.watchdog_timeout = None
         self.runner = QueueJobRunner.from_environ_or_config()
+        self._recover = False
 
     def sleep(self):
         pass
@@ -64,9 +65,22 @@ class WorkerJobRunner(server.Worker):
         self.runner.stop()
 
     def process_work(self):
+        if self._recover:
+            _logger.info("WorkerJobRunner (%s) runner is reinitialized", self.pid)
+            self.runner = QueueJobRunner.from_environ_or_config()
+            self._recover = False
         _logger.debug("WorkerJobRunner (%s) starting up", self.pid)
         time.sleep(START_DELAY)
         self.runner.run()
+
+    def signal_time_expired_handler(self, n, stack):
+        _logger.info(
+            "Worker (%d) CPU time limit (%s) reached.Stop gracefully and recover",
+            self.pid,
+            config["limit_time_cpu"],
+        )
+        self._recover = True
+        self.runner.stop()
 
 
 runner_thread = None


### PR DESCRIPTION
It is a strange case, but it can happen. Workers are reinitilized when they reach cpu time limit (https://github.com/odoo/odoo/blob/13.0/odoo/service/server.py#L911-L916)

But what will happen if it happens between these lines?
https://github.com/OCA/queue/blob/14.0/queue_job/jobrunner/runner.py#L425-L426 

I found the answer in my instance, the job will be marked as enqueued, but it will not be sent to odoo and will never be executed... Also, one channel will not be used, as everyone thinks it is already filled.

How to test it?
1. I created an instance with 2 workers, test_queue_job installed and just 1 channel (`root:1`) and `cpu_time_limit=5`
2. I created a scheduled action on model `test.queue.job`
```python
for _i in range(0, 1000):
    model.with_delay().testing_method()
```
3. I executed the action several times to create a lot of jobs. After some minutes, at the end, it happened and a job was enqueued but never executed (in my case 3000 jobs more or less).

With my solution, it will finalize the runner and start it again.

@guewen @simahawk 