### PR TITLE
[14.0][FIX] It seems that sometimes jobs doesn't have a job_method and the __repr__ failed

### DIFF
--- a/queue_job/delay.py
+++ b/queue_job/delay.py
@@ -492,8 +492,11 @@ class Delayable:
         return [self]
 
     def __repr__(self):
+        job_method = ""
+        if self._job_method:
+            job_method = self._job_method.__name__
         return "Delayable({}.{}({}, {}))".format(
-            self.recordset, self._job_method.__name__, self._job_args, self._job_kwargs
+            self.recordset, job_method, self._job_args, self._job_kwargs
         )
 
     def __del__(self):


### PR DESCRIPTION
That fix the issue into Shopinvader: https://github.com/shopinvader/odoo-shopinvader/runs/6897055192?check_suite_focus=true#step:8:7767 (cfr screenshot).
The issue happens into every PR in v14.0 (during merge or after a rebase).

The issue happens during the call to the `__repr__` of the `Delayable` object when the attribute `_job_method` is `None`.
https://github.com/OCA/queue/blob/14.0/queue_job/delay.py#L496
I didn't clearly identify why the `_job_method` is not filled. So maybe this PR is not a good solution.

![image](https://user-images.githubusercontent.com/30529208/173833278-3ca7e4d6-887e-4da7-8055-2af9d9af9fb5.png)
