### PR TITLE
[14.0] Fix cursor already closed error on retryable errors

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -133,6 +133,7 @@ class RunJobController(http.Controller):
             # traceback in the logs we should have the traceback when all
             # retries are exhausted
             env.cr.rollback()
+            return ""
 
         except (FailedJobError, Exception) as orig_exception:
             buff = StringIO()


### PR DESCRIPTION
When a job is postponed because of a retryable error, as the error
is not re-raised, we reach the new method

    self._enqueue_dependent_jobs(env, job)

With a closed cursor. Return early in case of postponing, as there is
no chance dependent jobs can become pending anyway.