### PR TITLE
[14.0] base_import_async: add a dedicated channel

### DIFF
--- a/base_import_async/data/queue_job_function_data.xml
+++ b/base_import_async/data/queue_job_function_data.xml
@@ -1,7 +1,13 @@
 <odoo noupdate="1">
+    <record model="queue.job.channel" id="channel_base_import">
+        <field name="name">base_import</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+
     <record id="job_function_base_import_import_split_file" model="queue.job.function">
         <field name="model_id" ref="base_import.model_base_import_import" />
         <field name="method">_split_file</field>
+        <field name="channel_id" ref="channel_base_import" />
         <field
             name="related_action"
             eval='{"func_name": "_related_action_attachment"}'
@@ -13,6 +19,7 @@
     >
         <field name="model_id" ref="base_import.model_base_import_import" />
         <field name="method">_import_one_chunk</field>
+        <field name="channel_id" ref="channel_base_import" />
         <field
             name="related_action"
             eval='{"func_name": "_related_action_attachment"}'


### PR DESCRIPTION
So we can configure the size of the channel.

We experienced a lot of locks and concurrent update issues on a table because tens of jobs were running in parallel (`root` is set with a high value).