### PR TITLE
Update job.py

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -516,7 +516,7 @@ class Job(object):
         The job is executed with the user which has initiated it.
         """
         self.retry += 1
-        if self.retry > self.max_retries:
+        if self.max_retries and self.retry > self.max_retries:
             type_, value, traceback = sys.exc_info()
             # change the exception type but keep the original
             # traceback and message:


### PR DESCRIPTION
I had an issue where the execution of the queue job would not except a RetryableJobError, but still end up requeuing itself (because a few rows failed ? honestly not sure). This caused it to never pass in the check for max retries. Putting that check before attempting the job fixed that issue.