### PR TITLE
[14.0][FIX] queue_job: Update documentation to remove unnecessary addon (base_sparse_field) from server_wide_modules.

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -105,7 +105,7 @@ Configuration
   [options]
   (...)
   workers = 6
-  server_wide_modules = web,queue_job,base_sparse_field
+  server_wide_modules = web,queue_job
 
   (...)
   [queue_job]

--- a/queue_job/readme/CONFIGURE.rst
+++ b/queue_job/readme/CONFIGURE.rst
@@ -18,7 +18,7 @@
   [options]
   (...)
   workers = 6
-  server_wide_modules = web,queue_job,base_sparse_field
+  server_wide_modules = web,queue_job
 
   (...)
   [queue_job]

--- a/queue_job/static/description/index.html
+++ b/queue_job/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Job Queue</title>
 <style type="text/css">
 
@@ -462,7 +462,7 @@ and <tt class="docutils literal"><span class="pre">--workers</span></tt> greater
 <span class="k">[options]</span>
 <span class="na">(...)</span>
 <span class="na">workers</span> <span class="o">=</span> <span class="s">6</span>
-<span class="na">server_wide_modules</span> <span class="o">=</span> <span class="s">web,queue_job,base_sparse_field</span>
+<span class="na">server_wide_modules</span> <span class="o">=</span> <span class="s">web,queue_job</span>
 
 <span class="na">(...)</span>
 <span class="k">[queue_job]</span>


### PR DESCRIPTION
Update documentation to remove unnecessary addon (`base_sparse_field`) from server_wide_modules.

Related to: https://github.com/OCA/queue/pull/443#discussion_r946913070

@Tecnativa 