### PR TITLE
[FIX] queue_job: delayable representation failed

### DIFF
--- a/queue_job/delay.py
+++ b/queue_job/delay.py
@@ -493,7 +493,10 @@ class Delayable:
 
     def __repr__(self):
         return "Delayable({}.{}({}, {}))".format(
-            self.recordset, self._job_method.__name__, self._job_args, self._job_kwargs
+            self.recordset,
+            self._job_method.__name__ if self._job_method else "",
+            self._job_args,
+            self._job_kwargs,
         )
 
     def __del__(self):


### PR DESCRIPTION
Represenation might fall in case of no job definition (as it happens on https://github.com/OCA/edi/blob/15.0/edi_oca/tests/test_record.py#L127), it tries to generate the log warning, but it fails

@simahawk 