### PR TITLE
[14.0][IMP] queue_job: do not list jobs in cancel modale

### DIFF
--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -245,6 +245,11 @@
                     string="Failed"
                     domain="[('state', '=', 'failed')]"
                 />
+                <filter
+                    name="cancelled"
+                    string="Cancelled"
+                    domain="[('state', '=', 'cancelled')]"
+                />
                 <group expand="0" string="Group By">
                     <filter
                         name="group_by_channel"

--- a/queue_job/wizards/queue_jobs_to_cancelled_views.xml
+++ b/queue_job/wizards/queue_jobs_to_cancelled_views.xml
@@ -6,9 +6,7 @@
         <field name="model">queue.jobs.to.cancelled</field>
         <field name="arch" type="xml">
             <form>
-                <group string="The selected jobs will be cancelled.">
-                    <field name="job_ids" nolabel="1" />
-                </group>
+                <span>Some jobs will be cancelled</span>
                 <footer>
                     <button
                         name="set_cancelled"

--- a/queue_job/wizards/queue_jobs_to_cancelled_views.xml
+++ b/queue_job/wizards/queue_jobs_to_cancelled_views.xml
@@ -6,7 +6,7 @@
         <field name="model">queue.jobs.to.cancelled</field>
         <field name="arch" type="xml">
             <form>
-                <span>Some jobs will be cancelled</span>
+                <span>Selected jobs will be cancelled</span>
                 <footer>
                     <button
                         name="set_cancelled"


### PR DESCRIPTION
Because, if the system is saturated you may need to quickly
cancel lot of jobs. Add a list here may be slow to generate.

Having a recap here do not add value if there is more than few items.