### PR TITLE
[16.0][FIX] Patch Request._get_session_and_dbname to get db from URL

### DIFF
--- a/queue_job/__init__.py
+++ b/queue_job/__init__.py
@@ -4,6 +4,7 @@ from . import models
 from . import wizards
 from . import jobrunner
 from .post_init_hook import post_init_hook
+from .post_load import post_load
 
 # shortcuts
 from .job import identity_exact

--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -31,4 +31,5 @@
     "development_status": "Mature",
     "maintainers": ["guewen"],
     "post_init_hook": "post_init_hook",
+    "post_load": "post_load",
 }

--- a/queue_job/post_load.py
+++ b/queue_job/post_load.py
@@ -1,0 +1,25 @@
+import logging
+
+from odoo import http
+
+_logger = logging.getLogger(__name__)
+
+
+def post_load():
+    _logger.info(
+        "Apply Request._get_session_and_dbname monkey patch to capture db"
+        " from request with multiple databases"
+    )
+    _get_session_and_dbname_orig = http.Request._get_session_and_dbname
+
+    def _get_session_and_dbname(self):
+        session, dbname = _get_session_and_dbname_orig(self)
+        if (
+            not dbname
+            and self.httprequest.path == "/queue_job/runjob"
+            and self.httprequest.args.get("db")
+        ):
+            dbname = self.httprequest.args["db"]
+        return session, dbname
+
+    http.Request._get_session_and_dbname = _get_session_and_dbname


### PR DESCRIPTION
In servers with multiple databases db is not captured from URL when processing jobs in /queue_job/runjob

With this patch db is set from the db param in URL when calling the runjob endpoint

Fixes #503


---

Maybe this monkey patch is not the most elegant or efficient solution, but this is the only way that I've managed to set the right db in order to call the petition with the `request._serve_db` method after the http.py complete refactor in v16.
