### PR TITLE
Fix job failure notifications - Correction of the targeted users

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -347,6 +347,7 @@ Next
   process (when running with --workers > 0)
 * [REF] ``@job`` and ``@related_action`` deprecated, any method can be delayed,
   and configured using ``queue.job.function`` records
+* [FIX] Handle connection to the database via Unix socket correctly.
 
 
 13.0.1.2.0 (2020-03-10)

--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -23,7 +23,7 @@ Job Queue
     :target: https://runbot.odoo-community.org/runbot/230/13.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This addon adds an integrated Job Queue to Odoo.
 
@@ -71,6 +71,7 @@ Features:
   description, number of retries
 * Related Actions: link an action on the job view, such as open the record
   concerned by the job
+* Mixin: add a smart button by inheritance. (See the mixin file for more details).
 
 **Table of contents**
 
@@ -420,7 +421,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-guewen| 
+|maintainer-guewen|
 
 This module is part of the `OCA/queue <https://github.com/OCA/queue/tree/13.0/queue_job>`_ project on GitHub.
 

--- a/queue_job/models/__init__.py
+++ b/queue_job/models/__init__.py
@@ -1,3 +1,4 @@
 from . import base
 from . import ir_model_fields
 from . import queue_job
+from . import mixin

--- a/queue_job/models/mixin.py
+++ b/queue_job/models/mixin.py
@@ -1,0 +1,75 @@
+from odoo import _, api, fields, models
+
+
+class QueueMixin(models.AbstractModel):
+    """Include this model within models inherited by an object
+    to benefit from default behaviors set here.
+
+    .. code-block:: python
+
+        class TestModel(models.Model):
+        _name = 'test'
+        _inherit = 'queue_job.mixin'
+
+    It also works fine with existing Odoo models::
+
+    .. code-block:: python
+
+        class AccMove(models.Model):
+            _inherit = [
+                'account.move',
+                'queue_job.mixin',
+            ]
+            _name = 'account.move'
+
+    In the derived class view, add the following lines::
+
+    .. code-block:: xml
+
+        <button name="open_queue_jobs"
+            type="object"
+            class="oe_stat_button"
+            icon="fa-list">
+            <field name="queue_job_count" string="QJobs" widget="statinfo" />
+        </button>
+    """
+
+    _name = "queue.mixin"
+    _description = "Queue Mixin"
+
+    @api.depends("queue_job_ids")
+    def _compute_queue_job_count(self):
+        for record in self:
+            record.queue_job_count = (
+                len(record.queue_job_ids)
+            )
+
+    queue_job_count = fields.Integer(
+        compute=_compute_queue_job_count,
+        string="Queue job count",
+        store=True,
+    )
+
+    queue_job_ids = fields.Many2many(
+        comodel_name="queue.job",
+        column1="record_id",
+        column2="job_id",
+        string="Queue jobs",
+        copy=False,
+        readonly=True,
+    )
+
+    def open_queue_jobs(self):
+        """Display queue jobs related to this model.
+        """
+
+        self.ensure_one()
+
+        return {
+            "context": self._context,
+            "domain": [("id", "in", self.queue_job_ids.ids)],
+            "name": _("%s - Queue jobs") % self.name,
+            "res_model": "queue.job",
+            "type": "ir.actions.act_window",
+            "view_mode": "tree,form",
+        }

--- a/queue_job/models/mixin.py
+++ b/queue_job/models/mixin.py
@@ -68,7 +68,7 @@ class QueueMixin(models.AbstractModel):
         return {
             "context": self._context,
             "domain": [("id", "in", self.queue_job_ids.ids)],
-            "name": _("%s - Queue jobs") % self.name,
+            "name": _("Queue jobs"),
             "res_model": "queue.job",
             "type": "ir.actions.act_window",
             "view_mode": "tree,form",

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -222,7 +222,7 @@ class QueueJob(models.Model):
         companies = self.mapped("company_id")
         domain = [("groups_id", "=", group.id)]
         if companies:
-            domain.append(("company_id", "in", companies.ids))
+            domain.append(("company_ids", "in", companies.ids))
         return domain
 
     def _message_failed_job(self):

--- a/queue_job/readme/HISTORY.rst
+++ b/queue_job/readme/HISTORY.rst
@@ -15,6 +15,7 @@ Next
   process (when running with --workers > 0)
 * [REF] ``@job`` and ``@related_action`` deprecated, any method can be delayed,
   and configured using ``queue.job.function`` records
+* [FIX] Handle connection to the database via Unix socket correctly.
 
 
 13.0.1.2.0 (2020-03-10)


### PR DESCRIPTION
On failure of a queue job, notifications should be sent to all users for which the access to the job company is authorized and not only users connected on this company.