### PR TITLE
[13.0][FIX] queue_job: On failure of a queue job, notifications should be sent to all users …

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -222,7 +222,7 @@ class QueueJob(models.Model):
         companies = self.mapped("company_id")
         domain = [("groups_id", "=", group.id)]
         if companies:
-            domain.append(("company_id", "in", companies.ids))
+            domain.append(("company_ids", "in", companies.ids))
         return domain
 
     def _message_failed_job(self):


### PR DESCRIPTION
…for which the access to the job company is authorized and not only users connected on this company.