### PR TITLE
[16.0][FWD][FIX] queue_job: fix Delayable.__repr__

### DIFF
--- a/queue_job/delay.py
+++ b/queue_job/delay.py
@@ -492,8 +492,11 @@ class Delayable:
         return [self]
 
     def __repr__(self):
+        job_method = ""
+        if self._job_method:
+            job_method = self._job_method.__name__
         return "Delayable({}.{}({}, {}))".format(
-            self.recordset, self._job_method.__name__, self._job_args, self._job_kwargs
+            self.recordset, job_method, self._job_args, self._job_kwargs
         )
 
     def __del__(self):


### PR DESCRIPTION
It seems that sometimes jobs doesn't have a job_method and the __repr__ failed

FWD port of https://github.com/OCA/queue/pull/440
With better commit msg.

As the commit msg won't match I'd blacklist that PR for oca-port.


No need to backport to v15.