### PR TITLE
[15.0][IMP] queue_job: Vacuum less jobs more often to avoid timeouts

### DIFF
--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -22,11 +22,11 @@
             <field eval="True" name="active" />
             <field name="user_id" ref="base.user_root" />
             <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
+            <field name="interval_type">hours</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall" />
             <field name="state">code</field>
-            <field name="code">model.autovacuum()</field>
+            <field name="code">model.autovacuum(limit_per_channel=1000)</field>
         </record>
     </data>
     <data noupdate="0">


### PR DESCRIPTION
In databases where lots of jobs are created it is possible for enough jobs to be generated in short enough time that eventually the autovacuum starts to time out. Since there is no cursor commit between unlinks, the timeout will also lead to the rollback of all the unlinks done so far, leading to no jobs being deleted. After the cron has timed out once, it is very likely that it will keep timing out as more jobs accumulate in the queue.

By running the cron more often but removing less jobs at once, the timeouts can be avoided without adding cursor commits.

For backwards compatibility, the limit per channel defaults to None so in databases where the cron already exists with the old execution interval the functionality remains the same.