### PR TITLE
[16.0] [FIX] base_import_async: remove default values from context when creating the attachment

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -88,10 +88,17 @@ class BaseImportImport(models.TransientModel):
         writer.writerow(fields)
         for row in data:
             writer.writerow(row)
-        # create attachment
+        # create attachment. Remove default values from context
+        context = self.env.context
+        context_copy = {}
+        for key in context.keys():
+            if not key.startswith("default_"):
+                context_copy[key] = context[key]
         datas = base64.encodebytes(f.getvalue().encode(encoding))
-        attachment = self.env["ir.attachment"].create(
-            {"name": file_name, "datas": datas}
+        attachment = (
+            self.env["ir.attachment"]
+            .with_context(**context_copy)
+            .create({"name": file_name, "datas": datas})
         )
         return attachment
 


### PR DESCRIPTION
Some default values might be present in context depending on the action we came from when clicking on 'import' button. These default values are not intended to be default values for the ir.attachment record.
In some cases they cause an error because a field with the same name exists on ir.attachment, as for e.g. the `'default_type'='opportunity'` value present in the standard crm.lead action context.