### PR TITLE
[12.0] [FIX] base_import_async: remove default values from context when creating the attachment

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -96,9 +96,14 @@ class BaseImportImport(models.TransientModel):
         writer.writerow(fields)
         for row in data:
             writer.writerow(row)
-        # create attachment
+        # create attachment. Remove default values from context
+        context = self.env.context
+        context_copy = {}
+        for key in context.keys():
+            if not key.startswith("default_"):
+                context_copy[key] = context[key]
         datas = base64.encodebytes(f.getvalue().encode(encoding))
-        attachment = self.env['ir.attachment'].create({
+        attachment = self.env['ir.attachment'].with_context(context_copy).create({
             'name': file_name,
             'datas': datas,
             'datas_fname': file_name,


### PR DESCRIPTION
Backporting https://github.com/OCA/queue/pull/528 from v16

Some default values might be present in context depending on the action we came from when clicking on 'import' button. These default values are not intended to be default values for the ir.attachment record.
In some cases they cause an error because a field with the same name exists on ir.attachment, as for e.g. the 'default_type'='opportunity' value present in the standard crm.lead action context.