### PR TITLE
[FIX] queue_job: remove `requests` from Python dependencies

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -8,7 +8,6 @@
     "license": "LGPL-3",
     "category": "Generic Modules",
     "depends": ["mail", "base_sparse_field"],
-    "external_dependencies": {"python": ["requests"]},
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # generated from manifests external_dependencies
-requests


### PR DESCRIPTION
Such dependency is already included in Odoo requirements using a pinned
version [1]. Adding here could cause to upgrade the library to an
incompatible version.

[1] https://github.com/odoo/odoo/blob/54e58b3e47ee/requirements.txt#L51