### PR TITLE
Handle cancelled state in job runner

### DIFF
--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -7,7 +7,7 @@ from heapq import heappop, heappush
 from weakref import WeakValueDictionary
 
 from ..exception import ChannelNotFound
-from ..job import DONE, ENQUEUED, FAILED, PENDING, STARTED, WAIT_DEPENDENCIES
+from ..job import CANCELLED, DONE, ENQUEUED, FAILED, PENDING, STARTED, WAIT_DEPENDENCIES
 
 NOT_DONE = (WAIT_DEPENDENCIES, PENDING, ENQUEUED, STARTED, FAILED)
 
@@ -1046,7 +1046,7 @@ class ChannelManager(object):
             job = ChannelJob(db_name, channel, uuid, seq, date_created, priority, eta)
             self._jobs_by_uuid[uuid] = job
         # state transitions
-        if not state or state == DONE:
+        if not state or state in (DONE, CANCELLED):
             job.channel.set_done(job)
         elif state == PENDING:
             job.channel.set_pending(job)


### PR DESCRIPTION
Towards #531 

From the point of view of the job runner, a cancelled job is the same as a done job: it frees the channel.
