### PR TITLE
[14.0] Fix trap_jobs() recordset comparison

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -111,7 +111,8 @@ class JobCall(typing.NamedTuple):
         if not isinstance(other, JobCall):
             return NotImplemented
         return (
-            self.method.__func__ == other.method.__func__
+            self.method.__self__ == other.method.__self__
+            and self.method.__func__ == other.method.__func__
             and self.args == other.args
             and self.kwargs == other.kwargs
             and self.properties == other.properties
@@ -280,7 +281,8 @@ class JobsTrap:
         enqueued_jobs = [
             job
             for job in self.enqueued_jobs
-            if job.func.__func__ == job_method.__func__
+            if job.func.__self__ == job_method.__self__
+            and job.func.__func__ == job_method.__func__
         ]
         return enqueued_jobs
 
@@ -293,7 +295,7 @@ class JobsTrap:
                 ", ".join("%s=%s" % (key, value) for key, value in call.kwargs.items())
             )
         return "<%s>.%s(%s) with properties (%s)" % (
-            call.method.__self__.__class__._name,
+            call.method.__self__,
             call.method.__name__,
             ", ".join(method_all_args),
             ", ".join("%s=%s" % (key, value) for key, value in call.properties.items()),

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -410,7 +410,9 @@ class OdooDocTestCase(doctest.DocTestCase):
     - output a more meaningful test name than default "DocTestCase.runTest"
     """
 
-    def __init__(self, doctest, optionflags=0, setUp=None, tearDown=None, checker=None):
+    def __init__(
+        self, doctest, optionflags=0, setUp=None, tearDown=None, checker=None, seq=0
+    ):
         super().__init__(
             doctest._dt_test,
             optionflags=optionflags,
@@ -418,6 +420,7 @@ class OdooDocTestCase(doctest.DocTestCase):
             tearDown=tearDown,
             checker=checker,
         )
+        self.test_sequence = seq
 
     def setUp(self):
         """Log an extra statement which test is started."""
@@ -441,8 +444,8 @@ def load_doctests(module):
             doctest.DocTestCase.doClassCleanups = lambda: None
             doctest.DocTestCase.tearDown_exceptions = []
 
-        for test in doctest.DocTestSuite(module):
-            odoo_test = OdooDocTestCase(test)
+        for idx, test in enumerate(doctest.DocTestSuite(module)):
+            odoo_test = OdooDocTestCase(test, seq=idx)
             odoo_test.test_tags = {"standard", "at_install", "queue_job", "doctest"}
             tests.addTest(odoo_test)
 

--- a/test_queue_job/tests/test_delay_mocks.py
+++ b/test_queue_job/tests/test_delay_mocks.py
@@ -13,7 +13,7 @@ from odoo.addons.queue_job.tests.common import mock_with_delay, trap_jobs
 
 
 class TestDelayMocks(common.SavepointCase):
-    def test_trap_jobs_on_with_delay(self):
+    def test_trap_jobs_on_with_delay_model(self):
         with trap_jobs() as trap:
             self.env["test.queue.job"].button_that_uses_with_delay()
             trap.assert_jobs_count(1)
@@ -32,6 +32,133 @@ class TestDelayMocks(common.SavepointCase):
                     priority=15,
                 ),
             )
+
+    def test_trap_jobs_on_with_delay_recordset(self):
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            recordset.button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            trap.assert_jobs_count(1, only=recordset.testing_method)
+
+            trap.assert_enqueued_job(
+                recordset.testing_method,
+                args=(1,),
+                kwargs={"foo": 2},
+                properties=dict(
+                    channel="root.test",
+                    description="Test",
+                    eta=15,
+                    identity_key=identity_exact,
+                    max_retries=1,
+                    priority=15,
+                ),
+            )
+
+    def test_trap_jobs_on_with_delay_recordset_no_properties(self):
+        """Verify that trap_jobs() can omit properties"""
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            recordset.button_that_uses_with_delay()
+
+            trap.assert_enqueued_job(
+                recordset.testing_method,
+                args=(1,),
+                kwargs={"foo": 2},
+            )
+
+    def test_trap_jobs_on_with_delay_recordset_partial_properties(self):
+        """Verify that trap_jobs() can check partially properties"""
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            recordset.button_that_uses_with_delay()
+
+            trap.assert_enqueued_job(
+                recordset.testing_method,
+                args=(1,),
+                kwargs={"foo": 2},
+                properties=dict(
+                    description="Test",
+                    eta=15,
+                ),
+            )
+
+    def test_trap_jobs_on_with_delay_assert_model_count_mismatch(self):
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            self.env["test.queue.job"].button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            with self.assertRaises(AssertionError, msg="0 != 1"):
+                trap.assert_jobs_count(1, only=recordset.testing_method)
+
+    def test_trap_jobs_on_with_delay_assert_recordset_count_mismatch(self):
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            recordset.button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            with self.assertRaises(AssertionError, msg="0 != 1"):
+                trap.assert_jobs_count(
+                    1, only=self.env["test.queue.job"].testing_method
+                )
+
+    def test_trap_jobs_on_with_delay_assert_model_enqueued_mismatch(self):
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            recordset.button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            message = (
+                r"Job <test\.queue.job\(\)>\.testing_method\(1, foo=2\) with "
+                r"properties \(channel=root\.test, description=Test, eta=15, "
+                "identity_key=<function identity_exact at 0x[0-9a-fA-F]+>, "
+                "max_retries=1, priority=15\\) was not enqueued\\.\n"
+                "Actual enqueued jobs:\n"
+                r" \* <test.queue.job\(%s,\)>.testing_method\(1, foo=2\) with properties "
+                r"\(priority=15, max_retries=1, eta=15, description=Test, channel=root.test, "
+                r"identity_key=<function identity_exact at 0x[0-9a-fA-F]+>\)"
+            ) % (recordset.id,)
+            with self.assertRaisesRegex(AssertionError, message):
+                trap.assert_enqueued_job(
+                    self.env["test.queue.job"].testing_method,
+                    args=(1,),
+                    kwargs={"foo": 2},
+                    properties=dict(
+                        channel="root.test",
+                        description="Test",
+                        eta=15,
+                        identity_key=identity_exact,
+                        max_retries=1,
+                        priority=15,
+                    ),
+                )
+
+    def test_trap_jobs_on_with_delay_assert_recordset_enqueued_mismatch(self):
+        recordset = self.env["test.queue.job"].create({"name": "test"})
+        with trap_jobs() as trap:
+            self.env["test.queue.job"].button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            message = (
+                r"Job <test\.queue.job\(%s,\)>\.testing_method\(1, foo=2\) with "
+                r"properties \(channel=root\.test, description=Test, eta=15, "
+                "identity_key=<function identity_exact at 0x[0-9a-fA-F]+>, "
+                "max_retries=1, priority=15\\) was not enqueued\\.\n"
+                "Actual enqueued jobs:\n"
+                r" \* <test.queue.job\(\)>.testing_method\(1, foo=2\) with properties "
+                r"\(priority=15, max_retries=1, eta=15, description=Test, channel=root.test, "
+                r"identity_key=<function identity_exact at 0x[0-9a-fA-F]+>\)"
+            ) % (recordset.id,)
+            with self.assertRaisesRegex(AssertionError, message):
+                trap.assert_enqueued_job(
+                    recordset.testing_method,
+                    args=(1,),
+                    kwargs={"foo": 2},
+                    properties=dict(
+                        channel="root.test",
+                        description="Test",
+                        eta=15,
+                        identity_key=identity_exact,
+                        max_retries=1,
+                        priority=15,
+                    ),
+                )
 
     def test_trap_jobs_on_graph(self):
         with trap_jobs() as trap:


### PR DESCRIPTION
The trap_jobs() test helper accepts any model/recordset as long as the job function is the same, which is not enough to verify that the job has been delayed on the expected recordset or model.

Tested job functions are "bound methods" so we can (and should) compare their `__self__`.

Example of assertion that would be valid:

    partner = self.env["res.partner"].create({"name": "foo"})
    with trap_jobs() as trap:
      partner.with_delay().do_something(42)
      trap.assert_enqueued_job(
          self.env["res.partner"].do_something,
          args=(42,)
      )

Now, it would fail with an error message like:

    E           AssertionError: Job <res.partner()>.do_something(42) with properties (channel=root.test, description=Do something, eta=15, identity_key=<function identity_exact at 0x7f01bfb54cb0>, max_retries=1, priority=15) was not enqueued.
    E           Actual enqueued jobs:
    E            * <res.partner(64,)>.do_something(42) with properties (priority=15, max_retries=1, eta=15, description=Do something, channel=root.test, identity_key=<function identity_exact at 0x7f01bfb54cb0>)