### PR TITLE
[15.0] [ENH] queue_job: identity_key enhancements

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -300,7 +300,7 @@ class Job(object):
             .search(
                 [
                     ("identity_key", "=", self.identity_key),
-                    ("state", "in", [PENDING, ENQUEUED]),
+                    ("state", "in", [WAIT_DEPENDENCIES, PENDING, ENQUEUED, STARTED]),
                 ],
                 limit=1,
             )

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -232,6 +232,7 @@ class JobsTrap:
                 self._perform_graph_jobs(jobs)
             else:
                 self._perform_single_jobs(jobs)
+        self.enqueued_jobs = []
 
     def _perform_single_jobs(self, jobs):
         # we probably don't want to replicate a perfect order here, but at
@@ -251,11 +252,14 @@ class JobsTrap:
 
     def _add_job(self, *args, **kwargs):
         job = Job(*args, **kwargs)
-        self.enqueued_jobs.append(job)
+        if not job.identity_key or all(
+            j.identity_key != job.identity_key for j in self.enqueued_jobs
+        ):
+            self.enqueued_jobs.append(job)
 
-        patcher = mock.patch.object(job, "store")
-        self._store_patchers.append(patcher)
-        patcher.start()
+            patcher = mock.patch.object(job, "store")
+            self._store_patchers.append(patcher)
+            patcher.start()
 
         job_args = kwargs.pop("args", None) or ()
         job_kwargs = kwargs.pop("kwargs", None) or {}


### PR DESCRIPTION
1. In production, a job which is waiting dependencies or which has started, but not completed, should not be repeated if the identity_key matches.
2. In tests, the mock queue handler is now enhanced to allow better mimicking of the identity_key blocks from production.
3. In tests, the mock queue handler now clears the enqueued jobs after performing them, to better reproduce what a production environment would do.