### PR TITLE
[16.0][FIX] base_import_async: restore class

### DIFF
--- a/base_import_async/readme/CONTRIBUTORS.rst
+++ b/base_import_async/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@ Other contributors include:
 * Guewen Baconnier (Camptocamp)
 * `Trobz <https://trobz.com>`_:
     * Dzung Tran <dungtd@trobz.com>
+* Daniel Duque (FactorLibre)

--- a/base_import_async/static/src/xml/import.xml
+++ b/base_import_async/static/src/xml/import.xml
@@ -7,7 +7,11 @@
 after splitting your file in small chunks that will be processed independently.
 Use this to import very large files."
             >
-                <input type="checkbox" class="form-check-input" id="oe_import_queue" />
+                <input
+                    type="checkbox"
+                    class="oe_import_queue form-check-input"
+                    id="oe_import_queue"
+                />
                 <label for="oe_import_queue">Import in the background</label>
             </div>
         </t>


### PR DESCRIPTION
In migration to 16.0, input class `oe_import_queue` [was replaced by another one](https://github.com/OCA/queue/pull/523/files#diff-9ff1ceedd4955454b8ab51e36cc6fadfbfa2cd51fcaaf01cba1b734d3b20c9a9L10) when it has to be added instead, causing the module not to work. In Javascript, input is searched by this class and it's not found, so value cannot be recovered and import is made synchronously.

This can be reproduced in runboat, trying to import any model and checking *Import in the background*. Records are imported in foreground.

Migration was made in https://github.com/OCA/queue/pull/523, seems that it was merged without simple functional testing

cc @gurneyalex @dzungtran89 