### PR TITLE
[14.0][IMP] export_async_schedule : Send attachments directly

### DIFF
--- a/base_export_async/data/mail_template.xml
+++ b/base_export_async/data/mail_template.xml
@@ -4,7 +4,7 @@
         <field name="name">Delay Export</field>
         <field
             name="subject"
-        >Export ${object.model_description} ${datetime.date.today()}</field>
+        >Export ${object.sudo().model_description} ${datetime.date.today()}</field>
         <field name="model_id" ref="base_export_async.model_delay_export" />
         <field name="auto_delete" eval="True" />
         <field name="body_html" type="html">

--- a/base_export_async/security/ir_rule.xml
+++ b/base_export_async/security/ir_rule.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
-    <record id="delay_export_user_only" model="ir.rule">
-        <field name="name">Only user can read delay.export</field>
+    <record id="delay_export_user" model="ir.rule">
+        <field name="name">Recipient can read delay.export</field>
         <field name="model_id" ref="model_delay_export" />
         <field name="groups" eval="[(4, ref('base.group_user'))]" />
         <field name="perm_read" eval="True" />
@@ -9,5 +9,15 @@
         <field name="perm_write" eval="False" />
         <field name="perm_unlink" eval="False" />
         <field name="domain_force">[('user_ids', 'in', user.id)]</field>
+    </record>
+    <record id="delay_export_admin" model="ir.rule">
+        <field name="name">Admin / Settings can read all delay.export</field>
+        <field name="model_id" ref="model_delay_export" />
+        <field name="groups" eval="[(4, ref('base.group_system'))]" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_unlink" eval="False" />
+        <field name="domain_force">[(1, '=', 1)]</field>
     </record>
 </odoo>

--- a/base_export_async/tests/test_base_export_async.py
+++ b/base_export_async/tests/test_base_export_async.py
@@ -81,6 +81,17 @@ class TestBaseExportAsync(common.TransactionCase):
         self.assertEqual(len(new_mail), 1)
         self.assertEqual(new_attachment.name, "res.partner.xls")
 
+    def test_export_mail_attachments(self):
+        """Check that the export generate an email and attached the generated attachment"""
+        params = json.loads(data_csv.get("data"))
+        mails = self.env["mail.mail"].search([])
+        self.delay_export_obj.export(
+            params, mail_template=None, is_export_file_attached_to_email=True
+        )
+        new_mail = self.env["mail.mail"].search([]) - mails
+        self.assertEqual(len(new_mail.attachment_ids), 1)
+        self.assertEqual(new_mail.attachment_ids.name, "res.partner.csv")
+
     def test_cron_delete(self):
         """Check that cron delete attachment after TTL"""
         params = json.loads(data_csv.get("data"))

--- a/export_async_schedule/views/export_async_schedule_views.xml
+++ b/export_async_schedule/views/export_async_schedule_views.xml
@@ -43,11 +43,17 @@
                             name="model_id"
                             options="{'no_open': True, 'no_create_edit': True}"
                         />
+                        <field
+                            name="mail_template_id"
+                            domain="[('model_id.model','=', 'delay.export')]"
+                        />
                         <field name="model_name" invisible="1" />
+                        <field name="is_mail_template_has_recipients" invisible="1" />
                         <field
                             name="user_ids"
                             widget="many2many_tags"
                             options="{'no_open': True, 'no_create_edit': True}"
+                            attrs="{'required': [('is_mail_template_has_recipients', '=', False)]}"
                         />
                         <field name="lang" />
                         <field
@@ -61,6 +67,7 @@
                         />
                         <field name="export_format" />
                         <field name="import_compat" />
+                        <field name="is_export_file_attached_to_email" />
                     </group>
                     <group name="scheduling" string="Scheduling">
                         <field name="next_execution" />


### PR DESCRIPTION
Improvement:

- Add the ability to specify mail template for export.async.schedule.

- Add the ability to attach the export attachment to the email.

These two new features will help if you want to send the export file to someone who doesn't have access to do (so they cannot open the link).