### PR TITLE
[15.0][FIX] Allow use in multidb enviroments and list_db = false

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -398,10 +398,16 @@ class QueueJobRunner(object):
         return runner
 
     def get_db_names(self):
+        """
+        >>> runner = QueueJobRunner()
+        >>> config["db_name"] = None
+        >>> runner.get_db_names()
+        ['odoo']
+        """
         if config["db_name"]:
             db_names = config["db_name"].split(",")
         else:
-            db_names = odoo.service.db.exp_list(True)
+            db_names = odoo.service.db.list_dbs(True)
         return db_names
 
     def close_databases(self, remove_jobs=True):


### PR DESCRIPTION
Update runner.py to work with multiDB & list_db = False

Applied exactly the same solution as #416 in V14, for some reason it became stalled
I have it in production via patchfile and everything works as expected.

Its related to #58 and #379

Previous PRs closed to keep the commit list usable