### PR TITLE
[14.0][IMP] queue_job: identity_key enhancements

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -300,7 +300,7 @@ class Job(object):
             .search(
                 [
                     ("identity_key", "=", self.identity_key),
-                    ("state", "in", [WAIT_DEPENDENCIES, PENDING, ENQUEUED, STARTED]),
+                    ("state", "in", [WAIT_DEPENDENCIES, PENDING, ENQUEUED]),
                 ],
                 limit=1,
             )

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -300,7 +300,7 @@ class Job(object):
             .search(
                 [
                     ("identity_key", "=", self.identity_key),
-                    ("state", "in", [PENDING, ENQUEUED]),
+                    ("state", "in", [WAIT_DEPENDENCIES, PENDING, ENQUEUED, STARTED]),
                 ],
                 limit=1,
             )

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -233,6 +233,7 @@ class JobsTrap:
                 self._perform_graph_jobs(jobs)
             else:
                 self._perform_single_jobs(jobs)
+        self.enqueued_jobs = []
 
     def _perform_single_jobs(self, jobs):
         # we probably don't want to replicate a perfect order here, but at
@@ -252,11 +253,14 @@ class JobsTrap:
 
     def _add_job(self, *args, **kwargs):
         job = Job(*args, **kwargs)
-        self.enqueued_jobs.append(job)
+        if not job.identity_key or all(
+            j.identity_key != job.identity_key for j in self.enqueued_jobs
+        ):
+            self.enqueued_jobs.append(job)
 
-        patcher = mock.patch.object(job, "store")
-        self._store_patchers.append(patcher)
-        patcher.start()
+            patcher = mock.patch.object(job, "store")
+            self._store_patchers.append(patcher)
+            patcher.start()
 
         job_args = kwargs.pop("args", None) or ()
         job_kwargs = kwargs.pop("kwargs", None) or {}

--- a/test_queue_job/tests/test_delay_mocks.py
+++ b/test_queue_job/tests/test_delay_mocks.py
@@ -82,6 +82,38 @@ class TestDelayMocks(common.SavepointCase):
                 ),
             )
 
+    def test_trap_with_identity_key(self):
+        with trap_jobs() as trap:
+            self.env["test.queue.job"].button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+            trap.assert_jobs_count(1, only=self.env["test.queue.job"].testing_method)
+
+            trap.assert_enqueued_job(
+                self.env["test.queue.job"].testing_method,
+                args=(1,),
+                kwargs={"foo": 2},
+                properties=dict(
+                    channel="root.test",
+                    description="Test",
+                    eta=15,
+                    identity_key=identity_exact,
+                    max_retries=1,
+                    priority=15,
+                ),
+            )
+
+            # Should not enqueue again
+            self.env["test.queue.job"].button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+
+            trap.perform_enqueued_jobs()
+            # Should no longer be enqueued
+            trap.assert_jobs_count(0)
+
+            # Can now requeue
+            self.env["test.queue.job"].button_that_uses_with_delay()
+            trap.assert_jobs_count(1)
+
     def test_trap_jobs_on_with_delay_assert_model_count_mismatch(self):
         recordset = self.env["test.queue.job"].create({"name": "test"})
         with trap_jobs() as trap:
@@ -218,6 +250,8 @@ class TestDelayMocks(common.SavepointCase):
 
             # perform the jobs
             trap.perform_enqueued_jobs()
+
+            trap.assert_jobs_count(0)
 
             logs = self.env["ir.logging"].search(
                 [


### PR DESCRIPTION
Replaces https://github.com/OCA/queue/pull/544

@richard-willdooit sorry, I really need to move this fwd on both 14 and 16.
I kept your commit here and I just dropped the odoo version from the msg.
I also added a specific commit to drop the STARTED state to make prominent the motivation provided by @guewen on https://github.com/OCA/queue/pull/546/files#r1232041609 (whole comment in the commit description).

I can fwd port to v16 later.