### PR TITLE
[FIX] queue_job: indicate job ID in failure message

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -379,8 +379,9 @@ class QueueJob(models.Model):
         """
         self.ensure_one()
         return _(
-            "Something bad happened during the execution of the job. "
-            "More details in the 'Exception Information' section."
+            "Something bad happened during the execution of job %s. "
+            "More details in the 'Exception Information' section.",
+            self.uuid,
         )
 
     def _needaction_domain_get(self):


### PR DESCRIPTION
Failed queue jobs include a button to get to the job when received by email, added automatically by the `mail.message_notification_email` template.

However, when customers forward the email to their support team, they sometimes just copy and paste the error message. Or sometimes they don't have HTML edition available, so as to copy and paste the full mail and include the button.

Thus, it's simpler to just add the job ID to the failure notification. This way, it's easier for the support team to understand the source of the failure.

@moduon MT-3813 @rafaelbn @Shide 