### PR TITLE
[16.0] Remove doctest from get_db_names method to avoid issues with Odoo.sh

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -398,13 +398,6 @@ class QueueJobRunner(object):
         return runner
 
     def get_db_names(self):
-        """
-        >>> runner = QueueJobRunner()
-        >>> config["db_name"] = None
-        >>> config["list_db"] = False
-        >>> runner.get_db_names()
-        ['odoo']
-        """
         if config["db_name"]:
             db_names = config["db_name"].split(",")
         else:


### PR DESCRIPTION
This is the hotfix for this issue: https://github.com/OCA/queue/issues/608 