### PR TITLE
[14.0] queue_job_cron_jobrunner:  avoid concurrent access on ir.cron

### DIFF
--- a/queue_job_cron_jobrunner/models/queue_job.py
+++ b/queue_job_cron_jobrunner/models/queue_job.py
@@ -150,7 +150,7 @@ class QueueJob(models.Model):
                 nextcall = at
         for cron in crons:
             if nextcall < cron.nextcall:
-                cron.nextcall = nextcall
+                cron.try_write({"nextcall": nextcall})
 
     def _ensure_cron_trigger(self):
         """Create cron triggers for these jobs"""


### PR DESCRIPTION
As odoo add a lock while running cron task we should only try to write
on it. If the cron is running while create new queue job records
we will wait next call.