### PR TITLE
[16.0][IMP] queue_job_cron: Avoid parallel run

### DIFF
--- a/queue_job_cron/readme/newsfragments/612.feature
+++ b/queue_job_cron/readme/newsfragments/612.feature
@@ -1,0 +1,9 @@
+By default prevent parallel run of the same cron job when run as queue job.
+
+When a cron job is run by odoo, the odoo runner will prevent parallel run
+of the same cron job. Before this change, this was not the case when the
+cron job was run as a queue job. A new option is added to the cron job when
+run as a queue job to prevent parallel run. This option is set to True by
+default. In this way, the behavior is now the same as when the cron job is run
+by odoo but you keep the possibility to disable this restriction when run as
+a queue job.

--- a/queue_job_cron/views/ir_cron_view.xml
+++ b/queue_job_cron/views/ir_cron_view.xml
@@ -8,6 +8,10 @@
             <field name="doall" position="after">
                 <field name="run_as_queue_job" />
                 <field
+                    name="no_parallel_queue_job_run"
+                    attrs="{'invisible': [('run_as_queue_job', '=', False)]}"
+                />
+                <field
                     name="channel_id"
                     attrs="{'invisible': [('run_as_queue_job', '=', False)],
                                 'required': [('run_as_queue_job', '=', True)]}"


### PR DESCRIPTION
By default, odoo never runs the same cron job in parallel. This commit uses the identity key mechanism to enforce this mechanism when a cron job is run as a queue job. This behaviour can be controlled by a new setting on the cron definition but is activated by default to keep the original behaviour