### PR TITLE
[FIX] queue_job: max retry

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -122,6 +122,8 @@ class RunJobController(http.Controller):
             job.store()
             env.cr.commit()
 
+        # FIXME: this exception never triggers up, so it never reaches
+        # `perform` method that handles retries.
         except RetryableJobError as err:
             # delay the job later, requeue
             retry_postpone(job, str(err), seconds=err.seconds)

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -512,6 +512,10 @@ class Job(object):
 
         The job is executed with the user which has initiated it.
         """
+        if self.max_retries and self.retry >= self.max_retries:
+            raise FailedJobError(
+                "Max. retries (%d) reached: %s" % (self.max_retries, self._uuid)
+            )
         self.retry += 1
         try:
             self.result = self.func(*tuple(self.args), **self.kwargs)


### PR DESCRIPTION
When job fails because of concurrent update error, it does not respect max retries set by the job. Problem is that ``perform`` method logic that handles re-try is never called, because ``runjob`` in controller that triggers jobs, catches expected exception and silences it. Though it is done to not pollute logs.

So for now, adding extra check before job is run, to make sure max retries are handled if it reached it.

Some context:

It looks like code that supposed to handle max retries, is never called. But I am not sure what would be the right way to trigger up exception as there is some logic in here https://github.com/OCA/queue/blob/e2c6bab9ebed9bf9f8d2110c79205a440da67327/queue_job/controllers/main.py#L125 that explicitly not want to raise that exception.

Not having max retries can be very problematic if your jobs can have many concurrent updates. Had some issue where somehow same job record (yes job record itself, not some other records, job would update) was being updated by two job runners at the same time and it would always fail and re-try. It had over 400 re-tries. And the only way to stop it, was to restart odoo.

For example, without this fix we can end up in situation like this:

![Selection_1050](https://github.com/OCA/queue/assets/7812986/93157654-2af9-4ae9-a023-cd960f848ac7)

