### PR TITLE
[14.0] queue_job: fix partial index to add `wait_dependencies` state

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Job Queue",
-    "version": "14.0.3.5.1",
+    "version": "14.0.3.5.2",
     "author": "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/queue",
     "license": "LGPL-3",

--- a/queue_job/migrations/14.0.3.5.2/pre-migration.py
+++ b/queue_job/migrations/14.0.3.5.2/pre-migration.py
@@ -1,0 +1,10 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo.tools.sql import table_exists
+
+
+def migrate(cr, version):
+    if table_exists(cr, "queue_job"):
+        # Drop index 'queue_job_identity_key_state_partial_index',
+        # it will be recreated during the update
+        cr.execute("DROP INDEX IF EXISTS queue_job_identity_key_state_partial_index;")

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -139,7 +139,7 @@ class QueueJob(models.Model):
             self._cr.execute(
                 "CREATE INDEX queue_job_identity_key_state_partial_index "
                 "ON queue_job (identity_key) WHERE state in ('pending', "
-                "'enqueued') AND identity_key IS NOT NULL;"
+                "'enqueued', 'wait_dependencies') AND identity_key IS NOT NULL;"
             )
 
     @api.depends("records")


### PR DESCRIPTION
Some details about the search performed by the method `job_record_with_same_identity_key` in file `queue_job/job.py`, the partial index wasn't used before:

### Before
```sql
 Limit  (cost=6874.52..6874.53 rows=1 width=20) (actual time=0.123..0.123 rows=0 loops=1)
   ->  Sort  (cost=6874.52..6874.53 rows=1 width=20) (actual time=0.121..0.121 rows=0 loops=1)
         Sort Key: date_created DESC, date_done DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using queue_job_state_index on queue_job  (cost=0.42..6874.51 rows=1 width=20) (actual time=0.113..0.113 rows=0 loops=1)
               Index Cond: ((state)::text = ANY ('{wait_dependencies,pending,enqueued}'::text[]))
               Filter: ((identity_key)::text = 'f75c2b628243d651bad356030a3021a95dbe7725'::text)
 Planning Time: 0.375 ms
 Execution Time: 0.161 ms
```

### After
```sql
 Limit  (cost=8.15..8.16 rows=1 width=20) (actual time=0.032..0.032 rows=0 loops=1)
   ->  Sort  (cost=8.15..8.16 rows=1 width=20) (actual time=0.030..0.030 rows=0 loops=1)
         Sort Key: date_created DESC, date_done DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using queue_job_identity_key_state_partial_index on queue_job  (cost=0.12..8.14 rows=1 width=20) (actual time=0.019..0.019 rows=0 loops=1)
               Index Cond: ((identity_key)::text = 'f75c2b628243d651bad356030a3021a95dbe7725'::text)
 Planning Time: 0.844 ms
 Execution Time: 0.094 ms
```