### PR TITLE
[13.0][FIX] base_import_async: add import context key as done in base_import

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -172,6 +172,15 @@ class BaseImportImport(models.TransientModel):
     def _import_one_chunk(self, model_name, attachment, options):
         model_obj = self.env[model_name]
         fields, data = self._read_csv_attachment(attachment, options)
+
+        # Introduce same keys as the one introduced in base_import
+        name_create_enabled_fields = options.get("name_create_enabled_fields", {})
+        import_limit = options.get("limit", None)
+        model_obj = model_obj.with_context(
+            import_file=True,
+            name_create_enabled_fields=name_create_enabled_fields,
+            _import_limit=import_limit,
+        )
         result = model_obj.load(fields, data)
         error_message = [
             message["message"]


### PR DESCRIPTION
The override of the method `do` is missing some context keys introduced when importing a file (by [base_import](https://github.com/odoo/odoo/blob/13.0/addons/base_import/models/base_import.py#L923)) in "asynchronous mode".

This PR introduces those keys in the job context.

For example:
When importing a product and changing its `standard_price`, Odoo will trigger the function "_change_standard_price" ([code](https://github.com/odoo/odoo/blob/4cc086d330b73514fbc64a7fcf22d8a7a9f1b691/addons/stock_account/models/product.py#L188)). But, doing the same operation asynchronously won't have the same effect since it is missing the context key "import_file" .