### PR TITLE
[14.0] queue_job: triggers stored computed fields before calling 'set_done()'

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -30,6 +30,9 @@ class RunJobController(http.Controller):
         _logger.debug("%s started", job)
 
         job.perform()
+        # Triggers any stored computed fields before calling 'set_done'
+        # so that will be part of the 'exec_time'
+        env["base"].flush()
         job.set_done()
         job.store()
         env["base"].flush()


### PR DESCRIPTION
So the time required to compute such fields by the ORM is taken into account when the `date_done` and `exec_time` values are set on the job.

**Before:** the execution time was reporting only the time taken by the delayed method itself. Time needed for stored computed fields triggered by the call to `flush()` wasn't included.

**After:** take into account all the time (delayed method + extra work of the ORM) in the execution time.

Without this change, the execution time is misleading and doesn't help to know if a job is (or became) slow.

cc @simahawk 