### PR TITLE
[16.0][FIX] queue_job: fix warning when triggering stored computed fields

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -36,7 +36,7 @@ class RunJobController(http.Controller):
         job.perform()
         # Triggers any stored computed fields before calling 'set_done'
         # so that will be part of the 'exec_time'
-        env["base"].flush()
+        env.flush_all()
         job.set_done()
         job.store()
         env.flush_all()


### PR DESCRIPTION
Starting from 16.0, we should call `env.flush_all()` instead of `env["base"].flush()`, like it is done few lines below.