### PR TITLE
[16.0][FIX] prevent a warning message

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -160,7 +160,7 @@ class RunJobController(http.Controller):
         exception_name = orig_exception.__class__.__name__
         if hasattr(orig_exception, "__module__"):
             exception_name = orig_exception.__module__ + "." + exception_name
-        exc_message = getattr(orig_exception, "name", str(orig_exception))
+        exc_message = orig_exception.args[0] if orig_exception.args else str(orig_exception)
         return {
             "exc_info": traceback_txt,
             "exc_name": exception_name,


### PR DESCRIPTION
Use args[0] instead of name to get the exception message as the name attribute is deprecated