### PR TITLE
[13.0][FIX] queue_job: triggers stored computed fields before calling 'set_done()'

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -30,6 +30,9 @@ class RunJobController(http.Controller):
         _logger.debug("%s started", job)
 
         job.perform()
+        # Triggers any stored computed fields before calling 'set_done'
+        # so that will be part of the 'exec_time'
+        env["base"].flush()
         job.set_done()
         job.store()
         env["base"].flush()


### PR DESCRIPTION
Backport of #637 from 14.0 to 13.0.