### PR TITLE
[13.0][FIX] queue_job: recompute with user 

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -30,6 +30,9 @@ class RunJobController(http.Controller):
         _logger.debug("%s started", job)
 
         job.perform()
+        # Triggers any stored computed fields before calling 'set_done'
+        # so that will be part of the 'exec_time'
+        env["base"].flush()
         job.set_done()
         job.store()
         env["base"].flush()

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -32,7 +32,7 @@ class RunJobController(http.Controller):
         job.perform()
         # Triggers any stored computed fields before calling 'set_done'
         # so that will be part of the 'exec_time'
-        env["base"].flush()
+        env["base"].with_user(job.user_id).flush()
         job.set_done()
         job.store()
         env["base"].flush()


### PR DESCRIPTION
When queue_job is not used, recomputing is done with the same user that did the changes.
queue_job changes that and the superuser is used instead. That causes problems. For example, when mail are sent, if the superuser has no mail address.

After this change, the original user is used instead of the superuser.

Goes after #648 