### PR TITLE
[FIX] `JobsTrap` `perform_enqueued_jobs` not working with jobs creating new jobs (issue OCA#651)

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -228,12 +228,12 @@ class JobsTrap:
             return job.graph_uuid or ""
 
         sorted_jobs = sorted(self.enqueued_jobs, key=by_graph)
+        self.enqueued_jobs = []
         for graph_uuid, jobs in groupby(sorted_jobs, key=by_graph):
             if graph_uuid:
                 self._perform_graph_jobs(jobs)
             else:
                 self._perform_single_jobs(jobs)
-        self.enqueued_jobs = []
 
     def _perform_single_jobs(self, jobs):
         # we probably don't want to replicate a perfect order here, but at


### PR DESCRIPTION
 `JobsTrap` `perform_enqueued_jobs` not working with jobs creating new jobs. After a call to `JobsTrap.perform_enqueued_jobs` the `enqueued_jobs` attribute is empty, even if one of the jobs executed had the effect of creating new jobs. That is because after executing the jobs of the queue in a loop, `JobsTrap.perform_enqueued_jobs` sets the `enqueued_jobs` to `[]`ignoring the newly created jobs.