### PR TITLE
[14.0][IMP] queue_job: add cron to purge dead jobs.

### DIFF
--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -10,6 +10,15 @@
             <field name="state">code</field>
             <field name="code">model.requeue_stuck_jobs()</field>
         </record>
+        <record id="ir_cron_queue_job_fail_dead_jobs()" model="ir.cron">
+            <field name="name">Jobs Garbage Collector</field>
+            <field name="interval_number">15</field>
+            <field name="interval_type">minutes</field>
+            <field name="numbercall">-1</field>
+            <field ref="model_queue_job" name="model_id" />
+            <field name="state">code</field>
+            <field name="code">model.fail_dead_jobs(240)</field>
+        </record>
         <!-- Queue-job-related subtypes for messaging / Chatter -->
         <record id="mt_job_failed" model="mail.message.subtype">
             <field name="name">Job failed</field>

--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -11,11 +11,11 @@
             <field name="code">model.requeue_stuck_jobs()</field>
         </record>
         <record id="ir_cron_queue_job_fail_dead_jobs()" model="ir.cron">
-            <field name="name">Jobs Garbage Collector</field>
+            <field name="name">Take care of unresponsive jobs</field>
             <field name="interval_number">15</field>
             <field name="interval_type">minutes</field>
             <field name="numbercall">-1</field>
-            <field ref="model_queue_job" name="model_id" />
+            <field name="model_id" ref="model_queue_job" />
             <field name="state">code</field>
             <field name="code">model.fail_dead_jobs(240)</field>
         </record>

--- a/queue_job/data/queue_data.xml
+++ b/queue_job/data/queue_data.xml
@@ -10,7 +10,7 @@
             <field name="state">code</field>
             <field name="code">model.requeue_stuck_jobs()</field>
         </record>
-        <record id="ir_cron_queue_job_fail_dead_jobs()" model="ir.cron">
+        <record id="ir_cron_queue_job_fail_dead_jobs" model="ir.cron">
             <field name="name">Take care of unresponsive jobs</field>
             <field name="interval_number">15</field>
             <field name="interval_type">minutes</field>

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -418,6 +418,48 @@ class QueueJob(models.Model):
         ).requeue()
         return True
 
+    def fail_dead_jobs(self, started_delta):
+        """Set as failed job started since too long ago.
+
+        Workers can be dead without anyone noticing
+        Dead workers stuck the channel and provoke
+        famine.
+
+        This function, mark jobs started longtime ago
+        as failed.
+
+        Cause of death can be CPU Time limit reached
+        a SIGTERM, a power shortage, we can't know, etc.
+        """
+        now = fields.datetime.now()
+        started_dl = now - timedelta(minutes=started_delta)
+        if started_delta <= 10:
+            raise exceptions.ValidationError(
+                _("started_delta is too low. Set at least 10min")
+            )
+        domain = [
+            "&",
+            ("date_started", "<=", fields.Datetime.to_string(started_dl)),
+            ("state", "=", "started"),
+        ]
+        job_model = self.env["queue.job"]
+        stuck_jobs = job_model.search(domain)
+        msg = {
+            "exc_info": "",
+            "exc_name": "Not responding worker. Is it dead ?",
+            "exc_message": (
+                "Check for odoo.service.server logs."
+                "Insestigate logs for CPU time limit reached or check system log"
+            ),
+        }
+        for job in stuck_jobs:
+            # TODO: manage retry:
+            # if retry < max_retry: retry=+1 and enqueue job instead
+            # else: set_failed
+            job_ = Job.load(self.env, job.uuid)
+            job_.set_failed(**msg)
+            job_.store()
+
     def _get_stuck_jobs_domain(self, queue_dl, started_dl):
         domain = []
         now = fields.datetime.now()

--- a/queue_job/readme/CONTRIBUTORS.rst
+++ b/queue_job/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 * Eric Antones <eantones@nuobit.com>
 * Simone Orsi <simone.orsi@camptocamp.com>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>


### PR DESCRIPTION
I'm trying to improve the remediation of started job stucked.

Cron Jobs Garbage Collector, with the second parameter, let you requeue started job. But if the root cause like a CPU limit error is still present after the requeue, the issue always reappear.

With this new cron, the job is marked as failed and not requeued.


