### PR TITLE
[IMP] queue_job: Display warning before displaying big dependency graphs

### DIFF
--- a/queue_job/static/src/js/queue_job_fields.js
+++ b/queue_job/static/src/js/queue_job_fields.js
@@ -16,6 +16,7 @@ odoo.define("queue_job.fields", function (require) {
         init: function () {
             this._super.apply(this, arguments);
             this.network = null;
+            this.forceRender = false;
             this.tabListenerInstalled = false;
         },
         start: function () {
@@ -87,6 +88,25 @@ odoo.define("queue_job.fields", function (require) {
                     arrows: "to",
                 });
             });
+
+            if (nodes.length * edges.length > 5000 && !this.forceRender) {
+                const warningDiv = document.createElement("div");
+                warningDiv.className = "alert alert-warning";
+                warningDiv.innerText =
+                    `This graph is big (${nodes.length} nodes, ` +
+                    `${edges.length} edges), it may take a while to display.`;
+                const button = document.createElement("button");
+                button.innerText = "Display anyway";
+                button.className = "btn btn-secondary";
+                button.onclick = function () {
+                    self.forceRender = true;
+                    warningDiv.parentNode.removeChild(warningDiv);
+                    self._render();
+                };
+                warningDiv.appendChild(button);
+                this.$el.append(warningDiv);
+                return;
+            }
 
             var data = {
                 // eslint-disable-next-line no-undef

--- a/queue_job/static/src/scss/queue_job_fields.scss
+++ b/queue_job/static/src/scss/queue_job_fields.scss
@@ -2,4 +2,11 @@
     width: 600px;
     height: 400px;
     border: 1px solid lightgray;
+    .alert {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
 }


### PR DESCRIPTION
Big dependency graphs currently slow down web page, this PR adds a warning in this case:

 
![20240604_09h13m27s_grim](https://github.com/OCA/queue/assets/271144/784b09a7-13fe-4e2b-aef7-3338771b5b35)
