### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/queue_job_cron_jobrunner/__manifest__.py
+++ b/queue_job_cron_jobrunner/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": "Run jobs without a dedicated JobRunner",
     "version": "17.0.1.0.0",
     "development_status": "Alpha",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "website": "https://github.com/OCA/queue",
     "license": "AGPL-3",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 17.0.