### PR TITLE
[16.0][IMP] queue_job: Requeue stuck jobs channel-based config

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -144,6 +144,8 @@ Configuration
   * ``started_delta``: Spent time in minutes after which a started job is considered stuck.
     This parameter should not be less than ``--limit-time-real // 60`` parameter in your configuration.
     Set it to 0 to disable this check. Set it to -1 to automate it, based in the server's ``--limit-time-real`` config parameter.
+  * These parameters are also configurable on a channel by channel basis, if set to 0 it will use the global value.
+    If set to -1 it will work the same as above.
 
   .. code-block:: python
 

--- a/queue_job/models/queue_job_channel.py
+++ b/queue_job/models/queue_job_channel.py
@@ -24,6 +24,20 @@ class QueueJobChannel(models.Model):
     removal_interval = fields.Integer(
         default=lambda self: self.env["queue.job"]._removal_interval, required=True
     )
+    enqueued_delta = fields.Integer(
+        help="If this value is set (in minutes), it will take preference over the "
+        "enqueued_delta parameter in the 'Jobs Garbage Collector' scheduled action. "
+        "This action is responsible for requeuing jobs stuck in the 'enqueued' "
+        "state for more than the configured time. If set to -1 it will use "
+        "the server's --limit-time-real config parameter.",
+    )
+    started_delta = fields.Integer(
+        help="If this value is set (in minutes), it will take preference over the "
+        "started_delta parameter in the 'Jobs Garbage Collector' scheduled action. "
+        "This action is responsible for requeuing jobs stuck in the 'started' "
+        "state for more than the configured time. If set to -1 it will use "
+        "the server's --limit-time-real config parameter.",
+    )
 
     _sql_constraints = [
         ("name_uniq", "unique(complete_name)", "Channel complete name must be unique")

--- a/queue_job/readme/CONFIGURE.rst
+++ b/queue_job/readme/CONFIGURE.rst
@@ -54,6 +54,8 @@
   * ``started_delta``: Spent time in minutes after which a started job is considered stuck.
     This parameter should not be less than ``--limit-time-real // 60`` parameter in your configuration.
     Set it to 0 to disable this check. Set it to -1 to automate it, based in the server's ``--limit-time-real`` config parameter.
+  * These parameters are also configurable on a channel by channel basis, if set to 0 it will use the global value.
+    If set to -1 it will work the same as above.
 
   .. code-block:: python
 

--- a/queue_job/static/description/index.html
+++ b/queue_job/static/description/index.html
@@ -503,6 +503,8 @@ Set it to 0 to disable this check.</li>
 <li><tt class="docutils literal">started_delta</tt>: Spent time in minutes after which a started job is considered stuck.
 This parameter should not be less than <tt class="docutils literal"><span class="pre">--limit-time-real</span> // 60</tt> parameter in your configuration.
 Set it to 0 to disable this check. Set it to -1 to automate it, based in the server’s <tt class="docutils literal"><span class="pre">--limit-time-real</span></tt> config parameter.</li>
+<li>These parameters are also configurable on a channel by channel basis, if set to 0 it will use the global value.
+If set to -1 it will work the same as above.</li>
 </ul>
 <pre class="code python literal-block">
 <span class="c1"># `model` corresponds to 'queue.job' model</span><span class="w">

--- a/queue_job/tests/test_model_job_channel.py
+++ b/queue_job/tests/test_model_job_channel.py
@@ -1,6 +1,9 @@
 # copyright 2018 Camptocamp
 # license lgpl-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
+import uuid
+from datetime import timedelta
+
 from psycopg2 import IntegrityError
 
 import odoo
@@ -57,3 +60,104 @@ class TestJobChannel(common.TransactionCase):
             {"name": "test", "parent_id": self.root_channel.id}
         )
         self.assertEqual(channel.name_get(), [(channel.id, "root.test")])
+
+    def _create_job(self, channel_name):
+        return (
+            self.env["queue.job"]
+            .with_context(
+                _job_edit_sentinel=self.env["queue.job"].EDIT_SENTINEL,
+            )
+            .create(
+                {
+                    "uuid": str(uuid.uuid4()),
+                    "user_id": self.env.user.id,
+                    "state": "pending",
+                    "model_name": "queue.job",
+                    "method_name": "write",
+                    "args": (),
+                    "channel": channel_name,
+                }
+            )
+        )
+
+    def test_requeue_stuck_jobs(self):
+        def _update_started_job_date(job, minutes):
+            date = odoo.fields.datetime.now() - timedelta(minutes=minutes)
+            job.write({"state": "started", "date_started": date})
+            self.assertEqual(job.state, "started")
+
+        def _update_enqueued_job_date(job, minutes):
+            date = odoo.fields.datetime.now() - timedelta(minutes=minutes)
+            job.write({"state": "enqueued", "date_enqueued": date})
+            self.assertEqual(job.state, "enqueued")
+
+        channel_1 = self.Channel.create(
+            {"name": "test", "parent_id": self.root_channel.id}
+        )
+        channel_2 = self.Channel.create(
+            {"name": "test2", "parent_id": self.root_channel.id}
+        )
+        job = self._create_job("root.test")
+        job_2 = self._create_job("root.test2")
+        self.assertEqual(job.channel, "root.test")
+        self.assertEqual(job_2.channel, "root.test2")
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job_2.state, "pending")
+        # Started
+        # Global config
+        _update_started_job_date(job, 10)
+        _update_started_job_date(job_2, 20)
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=0, started_delta=15)
+        self.assertEqual(job.state, "started")
+        self.assertEqual(job_2.state, "pending")
+        # Per channel config
+        _update_started_job_date(job, 10)
+        _update_started_job_date(job_2, 20)
+        channel_1.write({"started_delta": 5})
+        channel_2.write({"started_delta": 25})
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=0, started_delta=15)
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job_2.state, "started")
+        # Mixed
+        channel_1.write({"started_delta": 0})
+        channel_2.write({"started_delta": 25})
+        _update_started_job_date(job, 20)
+        _update_started_job_date(job_2, 20)
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=0, started_delta=15)
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job_2.state, "started")
+        # Enqueued
+        # Global config
+        _update_enqueued_job_date(job, 10)
+        _update_enqueued_job_date(job_2, 20)
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=15, started_delta=0)
+        self.assertEqual(job.state, "enqueued")
+        self.assertEqual(job_2.state, "pending")
+        # Per channel config
+        _update_enqueued_job_date(job, 10)
+        _update_enqueued_job_date(job_2, 20)
+        channel_1.write({"enqueued_delta": 5})
+        channel_2.write({"enqueued_delta": 25})
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=15, started_delta=0)
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job_2.state, "enqueued")
+        # Mixed
+        channel_1.write({"enqueued_delta": 0})
+        channel_2.write({"enqueued_delta": 25})
+        _update_enqueued_job_date(job, 20)
+        _update_enqueued_job_date(job_2, 20)
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=15, started_delta=0)
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job_2.state, "enqueued")
+        # job without queue.job.channel record for its channel
+        # it uses the global value
+        job_3 = self._create_job("root.test3")
+        channel_1.write({"started_delta": 50})
+        channel_2.write({"enqueued_delta": 50})
+        _update_started_job_date(job, 10)
+        _update_enqueued_job_date(job_2, 20)
+        _update_started_job_date(job_3, 30)
+        self.env["queue.job"].requeue_stuck_jobs(enqueued_delta=5, started_delta=5)
+        self.assertEqual(job.state, "started")
+        self.assertEqual(job_2.state, "enqueued")
+        self.assertEqual(job_3.state, "pending")

--- a/queue_job/views/queue_job_channel_views.xml
+++ b/queue_job/views/queue_job_channel_views.xml
@@ -17,6 +17,8 @@
                     />
                     <field name="complete_name" />
                     <field name="removal_interval" />
+                    <field name="enqueued_delta" />
+                    <field name="started_delta" />
                 </group>
                 <group>
                     <field name="job_function_ids" widget="many2many_tags" />


### PR DESCRIPTION
- Add the option to configure the `enqueued_delta` and `started_delta` parameters on a channel by channel basis. If not set it will use the global value set in the cron
- The use case we have for this is that we use the cron to catch any jobs that get stuck in `started` when the Odoo gets automatically deployed, in order for it to be mostly invisible to the end user and not have a blocked queue for long, the value should be low (5 or so). But we have some other processes that due to the length get sent to background tasks as jobs and might exceed this 5 minute mark, causing them to requeue infinitely. The ideal situation is optimizing the job or refactoring the whole thing to have <5min jobs but being able to allow some jobs to be longer is much more convenient and often will be enough of a solution to the issue.

Some extra notes
- The domain it generates is much bigger than the previous one depending on the number of channels, but the cron execution was still instantaneous during my tests on a database with 26 channels and 3.5m job records
- The `[("channel", "not in", searched_channels)]` part of the domain is for jobs that are created in a specific channel but without creating the corresponding `queue.job.channel` record, I would deem it technically a poor usage by the job creator (I have done it before) but it would be a regression for these cases if not taken into account