### PR TITLE
[16.0][FIX] base_import_async, add sudo call to models without explicit access

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -47,7 +47,9 @@ class BaseImportImport(models.TransientModel):
 
         # get the translated model name to build
         # a meaningful job description
-        search_result = self.env["ir.model"].name_search(self.res_model, operator="=")
+        search_result = (
+            self.env["ir.model"].sudo().name_search(self.res_model, operator="=")
+        )
         if search_result:
             translated_model_name = search_result[0][1]
         else:


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/commit/5dc4cff60a557e14b08440c227423291c407899b) explain why should be change access to this classes 

- ir.model
- ir.model.fields
- ir.model.data
- ir.model.fields.selection
- ir.ui.view