### PR TITLE
[IMP] queue_job: Don't raise a warning for valid context

### DIFF
--- a/queue_job/utils.py
+++ b/queue_job/utils.py
@@ -36,5 +36,5 @@ def must_run_without_delay(env):
             return True
 
     if env.context.get("queue_job__no_delay"):
-        _logger.warning("`queue_job__no_delay` ctx key found. NO JOB scheduled.")
+        _logger.info("`queue_job__no_delay` ctx key found. NO JOB scheduled.")
         return True

--- a/test_queue_job/tests/test_job_auto_delay.py
+++ b/test_queue_job/tests/test_job_auto_delay.py
@@ -32,11 +32,16 @@ class TestJobAutoDelay(JobCommonCase):
 
     def test_auto_delay_force_sync(self):
         """method forced to run synchronously"""
-        result = (
-            self.env["test.queue.job"]
-            .with_context(_job_force_sync=True)
-            .delay_me(1, kwarg=2)
+        with self.assertLogs(level="WARNING") as log_catcher:
+            result = (
+                self.env["test.queue.job"]
+                .with_context(_job_force_sync=True)
+                .delay_me(1, kwarg=2)
+            )
+        self.assertEqual(
+            len(log_catcher.output), 1, "Exactly one warning should be logged"
         )
+        self.assertIn(" ctx key found. NO JOB scheduled. ", log_catcher.output[0])
         self.assertTrue(result, (1, 2))
 
     def test_auto_delay_context_key_set(self):


### PR DESCRIPTION
As the 'queue_job__no_delay' context key is the valid one to use, don't raise warnings during tests, but log it as information level.

@simahawk Warning level should be only used to show something that could goes wrong (e.g.: deprecated methods, wrong definitions, ...). In this case, the use of the correct key context should not raise a warning and log as information only.

As I try to keep an eye on real warnings, they are lost in the crowd like:

https://github.com/OCA/sale-workflow/actions/runs/10522761814/job/29156065217#step:8:3025

