### PR TITLE
[18.0][FIX] queue_job: fix test cases from TestDelayable being skipped

### DIFF
--- a/queue_job/tests/test_delayable.py
+++ b/queue_job/tests/test_delayable.py
@@ -1,29 +1,40 @@
 # copyright 2019 Camptocamp
 # license agpl-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-import unittest
+import gc
+import logging
 from unittest import mock
+
+from odoo.tests import common
 
 from odoo.addons.queue_job.delay import Delayable, DelayableGraph
 
 
-class TestDelayable(unittest.TestCase):
+class TestDelayable(common.BaseCase):
     def setUp(self):
         super().setUp()
         self.recordset = mock.MagicMock(name="recordset")
 
     def test_delayable_set(self):
-        dl = Delayable(self.recordset)
-        dl.set(priority=15)
-        self.assertEqual(dl.priority, 15)
-        dl.set({"priority": 20, "description": "test"})
-        self.assertEqual(dl.priority, 20)
-        self.assertEqual(dl.description, "test")
+        # Use gc for garbage collection and use assertLogs to suppress WARNING
+        with self.assertLogs("odoo.addons.queue_job.delay", level=logging.WARNING):
+            dl = Delayable(self.recordset)
+            dl.set(priority=15)
+            self.assertEqual(dl.priority, 15)
+            dl.set({"priority": 20, "description": "test"})
+            self.assertEqual(dl.priority, 20)
+            self.assertEqual(dl.description, "test")
+            del dl
+            gc.collect()
 
     def test_delayable_set_unknown(self):
-        dl = Delayable(self.recordset)
-        with self.assertRaises(ValueError):
-            dl.set(foo=15)
+        # Use gc for garbage collection and use assertLogs to suppress WARNING
+        with self.assertLogs("odoo.addons.queue_job.delay", level=logging.WARNING):
+            dl = Delayable(self.recordset)
+            with self.assertRaises(ValueError):
+                dl.set(foo=15)
+            del dl
+            gc.collect()
 
     def test_graph_add_vertex_edge(self):
         graph = DelayableGraph()
@@ -55,23 +66,28 @@ class TestDelayable(unittest.TestCase):
         )
 
     def test_graph_connect(self):
-        node_tail = Delayable(self.recordset)
-        node_tail2 = Delayable(self.recordset)
-        node_middle = Delayable(self.recordset)
-        node_top = Delayable(self.recordset)
-        node_middle.on_done(node_tail)
-        node_middle.on_done(node_tail2)
-        node_top.on_done(node_middle)
-        collected = node_top._graph._connect_graphs()
-        self.assertEqual(
-            collected._graph,
-            {
-                node_tail: set(),
-                node_tail2: set(),
-                node_middle: {node_tail, node_tail2},
-                node_top: {node_middle},
-            },
-        )
+        # Use gc for garbage collection and use assertLogs to suppress WARNING
+        with self.assertLogs("odoo.addons.queue_job.delay", level=logging.WARNING):
+            node_tail = Delayable(self.recordset)
+            node_tail2 = Delayable(self.recordset)
+            node_middle = Delayable(self.recordset)
+            node_top = Delayable(self.recordset)
+            node_middle.on_done(node_tail)
+            node_middle.on_done(node_tail2)
+            node_top.on_done(node_middle)
+            collected = node_top._graph._connect_graphs()
+            self.assertEqual(
+                collected._graph,
+                {
+                    node_tail: set(),
+                    node_tail2: set(),
+                    node_middle: {node_tail, node_tail2},
+                    node_top: {node_middle},
+                },
+            )
+
+            del node_tail, node_tail2, node_middle, node_top, collected
+            gc.collect()
 
     def test_graph_paths(self):
         graph = DelayableGraph(


### PR DESCRIPTION
### Issue: Testcases from TestDelayable are being skipped
```
2024-10-16 05:23:34,643 427499 DEBUG v18c_queue_job odoo.tests.tag_selector: Skipping test 'test_delayable_set (odoo.addons.queue_job.tests.test_delayable.TestDelayable.test_delayable_set)' because no test_tag found. 
2024-10-16 05:23:34,644 427499 DEBUG v18c_queue_job odoo.tests.tag_selector: Skipping test 'test_delayable_set_unknown (odoo.addons.queue_job.tests.test_delayable.TestDelayable.test_delayable_set_unknown)' because no test_tag found. 
2024-10-16 05:23:34,644 427499 DEBUG v18c_queue_job odoo.tests.tag_selector: Skipping test 'test_graph_add_vertex_edge (odoo.addons.queue_job.tests.test_delayable.TestDelayable.test_graph_add_vertex_edge)' because no test_tag found. 
.........

```
### Reason:
- Testcases from **`TestDelayable`** are being skipped because the class is not inheriting from **`odoo.tests.common.BaseCase`**. This results in testcases not being assigned `test-tags` automatically and odoo will skip those testcases.