### PR TITLE
[FIX] Stop using deprecated odoo.registry function.

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -11,7 +11,8 @@ from io import StringIO
 from psycopg2 import OperationalError, errorcodes
 from werkzeug.exceptions import BadRequest, Forbidden
 
-from odoo import SUPERUSER_ID, _, api, http, registry
+from odoo import SUPERUSER_ID, _, api, http
+from odoo.modules.registry import Registry
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 from ..delay import chain, group
@@ -79,7 +80,7 @@ class RunJobController(http.Controller):
 
         def retry_postpone(job, message, seconds=None):
             job.env.clear()
-            with registry(job.env.cr.dbname).cursor() as new_cr:
+            with Registry(job.env.cr.dbname).cursor() as new_cr:
                 job.env = api.Environment(new_cr, SUPERUSER_ID, {})
                 job.postpone(result=message, seconds=seconds)
                 job.set_pending(reset_retry=False)
@@ -130,7 +131,7 @@ class RunJobController(http.Controller):
             traceback_txt = buff.getvalue()
             _logger.error(traceback_txt)
             job.env.clear()
-            with registry(job.env.cr.dbname).cursor() as new_cr:
+            with Registry(job.env.cr.dbname).cursor() as new_cr:
                 job.env = job.env(cr=new_cr)
                 vals = self._get_failure_values(job, traceback_txt, orig_exception)
                 job.set_failed(**vals)


### PR DESCRIPTION
This avoids a DeprecationWarning introduced in Odoo 17 by https://github.com/odoo/odoo/pull/178784

> WARNING odoo py.warnings: /mnt/extra-addons/oca/queue/queue_job/controllers/main.py:82: DeprecationWarning: Use directly odoo.modules.registry.Registry