### PR TITLE
[14.0][REF] Clean-up for Python 3

### DIFF
--- a/base_export_async/tests/test_base_export_async.py
+++ b/base_export_async/tests/test_base_export_async.py
@@ -42,7 +42,7 @@ data_xls = {
 
 class TestBaseExportAsync(common.TransactionCase):
     def setUp(self):
-        super(TestBaseExportAsync, self).setUp()
+        super().setUp()
         self.delay_export_obj = self.env["delay.export"]
         self.job_obj = self.env["queue.job"]
         _request_stack.push(

--- a/queue_job/delay.py
+++ b/queue_job/delay.py
@@ -609,7 +609,7 @@ class Delayable:
         self._generated_job.perform()
 
 
-class DelayableRecordset(object):
+class DelayableRecordset:
     """Allow to delay a method for a recordset (shortcut way)
 
     Usage::

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -105,7 +105,7 @@ def identity_exact_hasher(job_):
 
 
 @total_ordering
-class Job(object):
+class Job:
     """A Job is a task to execute. It is the in-memory representation of a job.
 
     Jobs are stored in the ``queue.job`` Odoo Model, but they are handled

--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -14,7 +14,7 @@ NOT_DONE = (WAIT_DEPENDENCIES, PENDING, ENQUEUED, STARTED, FAILED)
 _logger = logging.getLogger(__name__)
 
 
-class PriorityQueue(object):
+class PriorityQueue:
     """A priority queue that supports removing arbitrary objects.
 
     Adding an object already in the queue is a no op.
@@ -103,7 +103,7 @@ class PriorityQueue(object):
 
 
 @total_ordering
-class ChannelJob(object):
+class ChannelJob:
     """A channel job is attached to a channel and holds the properties of a
     job that are necessary to prioritise them.
 
@@ -205,7 +205,7 @@ class ChannelJob(object):
         return self.sorting_key() < other.sorting_key()
 
 
-class ChannelQueue(object):
+class ChannelQueue:
     """A channel queue is a priority queue for jobs.
 
     Jobs with an eta are set aside until their eta is past due, at
@@ -334,7 +334,7 @@ class ChannelQueue(object):
         return wakeup_time
 
 
-class Channel(object):
+class Channel:
     """A channel for jobs, with a maximum capacity.
 
     When jobs are created by queue_job modules, they may be associated
@@ -581,7 +581,7 @@ def split_strip(s, sep, maxsplit=-1):
     return [x.strip() for x in s.split(sep, maxsplit)]
 
 
-class ChannelManager(object):
+class ChannelManager:
     """High level interface for channels
 
     This class handles:

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -259,7 +259,7 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
     thread.start()
 
 
-class Database(object):
+class Database:
     def __init__(self, db_name):
         self.db_name = db_name
         connection_info = _connection_info_for(db_name)
@@ -344,7 +344,7 @@ class Database(object):
             )
 
 
-class QueueJobRunner(object):
+class QueueJobRunner:
     def __init__(
         self,
         scheme="http",

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -428,7 +428,7 @@ class OdooDocTestCase(doctest.DocTestCase):
 
     def setUp(self):
         """Log an extra statement which test is started."""
-        super(OdooDocTestCase, self).setUp()
+        super().setUp()
         logging.getLogger(__name__).info("Running tests for %s", self._dt_test.name)
 
 

--- a/queue_job_subscribe/tests/test_job_subscribe.py
+++ b/queue_job_subscribe/tests/test_job_subscribe.py
@@ -8,7 +8,7 @@ from odoo.addons.queue_job.job import Job
 
 class TestJobSubscribe(common.TransactionCase):
     def setUp(self):
-        super(TestJobSubscribe, self).setUp()
+        super().setUp()
         grp_queue_job_manager = self.ref("queue_job.group_queue_job_manager")
         self.other_partner_a = self.env["res.partner"].create(
             {"name": "My Company a", "is_company": True, "email": "test@tes.ttest"}

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -76,7 +76,7 @@ class ModelTestQueueJob(models.Model):
         return
 
     def mapped(self, func):
-        return super(ModelTestQueueJob, self).mapped(func)
+        return super().mapped(func)
 
     def job_alter_mutable(self, mutable_arg, mutable_kwarg=None):
         mutable_arg.append(2)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -651,7 +651,7 @@ class TestJobStorageMultiCompany(common.TransactionCase):
     """Test storage of jobs"""
 
     def setUp(self):
-        super(TestJobStorageMultiCompany, self).setUp()
+        super().setUp()
         self.queue_job = self.env["queue.job"]
         grp_queue_job_manager = self.ref("queue_job.group_queue_job_manager")
         User = self.env["res.users"]

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -90,7 +90,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         self.assertEqual(test_job.retry, 1)
 
     def test_on_instance_method(self):
-        class A(object):
+        class A:
             def method(self):
                 pass
 

--- a/test_queue_job/tests/test_job_channels.py
+++ b/test_queue_job/tests/test_job_channels.py
@@ -9,7 +9,7 @@ from odoo.addons.queue_job.job import Job
 
 class TestJobChannels(common.TransactionCase):
     def setUp(self):
-        super(TestJobChannels, self).setUp()
+        super().setUp()
         self.function_model = self.env["queue.job.function"]
         self.channel_model = self.env["queue.job.channel"]
         self.test_model = self.env["test.queue.channel"]

--- a/test_queue_job/tests/test_job_function.py
+++ b/test_queue_job/tests/test_job_function.py
@@ -4,7 +4,7 @@ from odoo import exceptions
 
 class TestJobFunction(common.TransactionCase):
     def setUp(self):
-        super(TestJobFunction, self).setUp()
+        super().setUp()
         self.test_function_model = self.env.ref(
             "queue_job.job_function_queue_job__test_job"
         )


### PR DESCRIPTION
This will be forward ported to branches 15.0+
- [REF] remove explicit 'object' inheritance
- [REF] remove explicit super() arguments