### PR TITLE
[14.0][IMP] queue_job: perform_enqueued_jobs should filter the context

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -256,6 +256,7 @@ class JobsTrap:
         if not job.identity_key or all(
             j.identity_key != job.identity_key for j in self.enqueued_jobs
         ):
+            self._prepare_context(job)
             self.enqueued_jobs.append(job)
 
             patcher = mock.patch.object(job, "store")
@@ -273,6 +274,13 @@ class JobsTrap:
             )
         )
         return job
+
+    def _prepare_context(self, job):
+        # pylint: disable=context-overridden
+        job_model = job.job_model.with_context({})
+        field_records = job_model._fields["records"]
+        # Filter the context to simulate store/load of the job
+        job.recordset = field_records.convert_to_write(job.recordset, job_model)
 
     def __enter__(self):
         return self

--- a/test_queue_job/tests/test_delay_mocks.py
+++ b/test_queue_job/tests/test_delay_mocks.py
@@ -268,6 +268,27 @@ class TestDelayMocks(common.SavepointCase):
             self.assertEqual(logs[2].message, "test_trap_jobs_perform graph 3")
             self.assertEqual(logs[3].message, "test_trap_jobs_perform graph 1")
 
+    def test_trap_jobs_prepare_context(self):
+        """Verify that context is filtered consistently.
+
+        Method '_job_prepare_context_before_enqueue_keys' is redefined on 'test.queue.job'.
+        Key 'lang' is whitelisted, while key 'config_key' is filtered out.
+        """
+        # pylint: disable=context-overridden
+        with trap_jobs() as trap:
+            model1 = self.env["test.queue.job"].with_context({"config_key": 42})
+            model2 = self.env["test.queue.job"].with_context(
+                {"config_key": 42, "lang": "it_IT"}
+            )
+            model1.with_delay().testing_method("0", "K", return_context=1)
+            model2.with_delay().testing_method("0", "K", return_context=1)
+
+            [job1, job2] = trap.enqueued_jobs
+            trap.perform_enqueued_jobs()
+
+            self.assertEqual(job1.result, {"job_uuid": mock.ANY})
+            self.assertEqual(job2.result, {"job_uuid": mock.ANY, "lang": "it_IT"})
+
     def test_mock_with_delay(self):
         with mock_with_delay() as (delayable_cls, delayable):
             self.env["test.queue.job"].button_that_uses_with_delay()


### PR DESCRIPTION
This enhancement is needed to write more accurate tests when the delayed method is context-sensitive.

We had a bug not identified during tests because of this :(