### PR TITLE
[FIX][18.0] queue_job: indicate that run_job need a read/write connection

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -73,7 +73,13 @@ class RunJobController(http.Controller):
             else:
                 break
 
-    @http.route("/queue_job/runjob", type="http", auth="none", save_session=False)
+    @http.route(
+        "/queue_job/runjob",
+        type="http",
+        auth="none",
+        save_session=False,
+        readonly=False,
+    )
     def runjob(self, db, job_uuid, **kw):
         http.request.session.db = db
         env = http.request.env(user=SUPERUSER_ID)


### PR DESCRIPTION
Without this fix, if db_replica_host is set, Odoo might pass a readonly database cursor and the FOR UPDATE in the method would fail.