### PR TITLE
[18.0][IMP] queue_job: perform_enqueued_jobs should filter the context

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -428,8 +428,9 @@ allow-list.
 
 The default allow-list is ("tz", "lang", "allowed_company_ids",
 "force_company", "active_test"). It can be customized in
-``Base._job_prepare_context_before_enqueue_keys``. **Bypass jobs on
-running Odoo**
+``Base._job_prepare_context_before_enqueue_keys``.
+
+**Bypass jobs on running Odoo**
 
 When you are developing (ie: connector modules) you might want to bypass
 the queue job and run your code immediately.

--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -255,6 +255,7 @@ class JobsTrap:
         if not job.identity_key or all(
             j.identity_key != job.identity_key for j in self.enqueued_jobs
         ):
+            self._prepare_context(job)
             self.enqueued_jobs.append(job)
 
             patcher = mock.patch.object(job, "store")
@@ -272,6 +273,13 @@ class JobsTrap:
             )
         )
         return job
+
+    def _prepare_context(self, job):
+        # pylint: disable=context-overridden
+        job_model = job.job_model.with_context({})
+        field_records = job_model._fields["records"]
+        # Filter the context to simulate store/load of the job
+        job.recordset = field_records.convert_to_write(job.recordset, job_model)
 
     def __enter__(self):
         return self

--- a/test_queue_job/tests/test_delay_mocks.py
+++ b/test_queue_job/tests/test_delay_mocks.py
@@ -271,6 +271,12 @@ class TestDelayMocks(common.TransactionCase):
             self.assertEqual(logs[3].message, "test_trap_jobs_perform graph 1")
 
     def test_trap_jobs_prepare_context(self):
+        """Context is transferred to the job according to an allow-list.
+
+        Default allow-list is:
+        ("tz", "lang", "allowed_company_ids", "force_company", "active_test")
+        It can be customized in ``Base._job_prepare_context_before_enqueue_keys``.
+        """
         # pylint: disable=context-overridden
         with trap_jobs() as trap:
             model1 = self.env["test.queue.job"].with_context({"config_key": 42})


### PR DESCRIPTION
This enhancement is needed to write more accurate tests when the delayed method is context-sensitive.

Same as:
- Odoo 14 #738