### PR TITLE
[16.0][IMP] queue_job: improve form view layout for better readability

### DIFF
--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -107,7 +107,9 @@
                                 string="Result"
                                 attrs="{'invisible': [('result', '=', False)]}"
                             >
-                            <field nolabel="1" name="result" />
+                            <div id="result" colspan="2">
+                                <field nolabel="1" name="result" />
+                            </div>
                         </group>
                         <group
                                 name="exc_info"
@@ -119,7 +121,7 @@
                                 <label for="exc_name" string="Exception:" />
                                 <field name="exc_name" class="oe_inline" />
                             </div>
-                            <field colspan="4" nolabel="1" name="exc_info" />
+                            <field colspan="2" nolabel="1" name="exc_info" />
                         </group>
                       </page>
                       <page


### PR DESCRIPTION
#### **Description**
This PR improves the layout of the `queue.job` form view by enhancing the **Results** and **Exception Information** sections for better readability and alignment.

#### **Changes**
- Wrapped `result` in a `<div>` for better spacing.
- Adjusted `exc_info` layout for improved structure.

#### **Why?**
This ensures a cleaner UI, making job results and errors easier to read.

#### **View example**
**Before:**
![image](https://github.com/user-attachments/assets/d623fa5f-6746-4259-9ff8-fa5c0bdd9447)
**After:**
![image](https://github.com/user-attachments/assets/38423084-f9a1-4886-bf14-6593910a2030)
