### PR TITLE
[FIX] queue_job: job runner open pipe that are never closed properly

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -367,6 +367,16 @@ class QueueJobRunner:
         self._stop = False
         self._stop_pipe = os.pipe()
 
+    def __del__(self):
+        try:
+            os.close(self._stop_pipe[0])
+        except OSError:
+            pass
+        try:
+            os.close(self._stop_pipe[1])
+        except OSError:
+            pass
+
     @classmethod
     def from_environ_or_config(cls):
         scheme = os.environ.get("ODOO_QUEUE_JOB_SCHEME") or queue_job_config.get(

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -3,8 +3,57 @@
 
 # pylint: disable=odoo-addons-relative-import
 # we are testing, we want to test as we were an external consumer of the API
+import os
+
+from odoo.tests import BaseCase, tagged
+
 from odoo.addons.queue_job.jobrunner import runner
 
 from .common import load_doctests
 
 load_tests = load_doctests(runner)
+
+
+@tagged("-at_install", "post_install")
+class TestRunner(BaseCase):
+    @classmethod
+    def _is_open_file_descriptor(cls, fd):
+        try:
+            os.fstat(fd)
+            return True
+        except OSError:
+            return False
+
+    def test_runner_file_descriptor(self):
+        a_runner = runner.QueueJobRunner.from_environ_or_config()
+
+        read_fd, write_fd = a_runner._stop_pipe
+        self.assertTrue(self._is_open_file_descriptor(read_fd))
+        self.assertTrue(self._is_open_file_descriptor(write_fd))
+
+        del a_runner
+
+        self.assertFalse(self._is_open_file_descriptor(read_fd))
+        self.assertFalse(self._is_open_file_descriptor(write_fd))
+
+    def test_runner_file_closed_read_descriptor(self):
+        a_runner = runner.QueueJobRunner.from_environ_or_config()
+
+        read_fd, write_fd = a_runner._stop_pipe
+        os.close(read_fd)
+
+        del a_runner
+
+        self.assertFalse(self._is_open_file_descriptor(read_fd))
+        self.assertFalse(self._is_open_file_descriptor(write_fd))
+
+    def test_runner_file_closed_write_descriptor(self):
+        a_runner = runner.QueueJobRunner.from_environ_or_config()
+
+        read_fd, write_fd = a_runner._stop_pipe
+        os.close(write_fd)
+
+        del a_runner
+
+        self.assertFalse(self._is_open_file_descriptor(read_fd))
+        self.assertFalse(self._is_open_file_descriptor(write_fd))


### PR DESCRIPTION
this make a lot of open file descriptors that we got the limit while instentiate jobrunner from queue_job_cron_jobrunner in the current channel implementation https://github.com/OCA/queue/pull/750