### PR TITLE
[14.0][ADD] base_export_async: make attachment accessible to portal users

### DIFF
--- a/base_export_async/models/delay_export.py
+++ b/base_export_async/models/delay_export.py
@@ -106,6 +106,10 @@ class DelayExport(models.Model):
             attachment.name,
         )
 
+        if any(user.has_group("base.group_portal") for user in users):
+            attachment.generate_access_token()
+            url += f"&access_token={attachment.access_token}"
+
         time_to_live = (
             self.env["ir.config_parameter"].sudo().get_param("attachment.ttl", 7)
         )

--- a/base_export_async/tests/test_base_export_async.py
+++ b/base_export_async/tests/test_base_export_async.py
@@ -97,3 +97,22 @@ class TestBaseExportAsync(common.TransactionCase):
 
         # The attachment must be deleted
         self.assertFalse(new_attachment.exists())
+
+    def test_portal_export(self):
+        """Check that we make attachments externally accessible for portal users"""
+        portal_user = self.env["res.users"].create(
+            {
+                "login": "base_export_async_portal_user",
+                "name": "base_export_async_portal_user",
+                "groups_id": self.env.ref("base.group_portal").ids,
+            }
+        )
+        params = json.loads(data_csv.get("data"))
+        params["user_ids"] = portal_user.ids
+        attachments = self.env["ir.attachment"].search([])
+        mails = self.env["mail.mail"].search([])
+        self.delay_export_obj.export(params)
+        new_attachment = self.env["ir.attachment"].search([]) - attachments
+        self.assertTrue(new_attachment.access_token)
+        new_mail = self.env["mail.mail"].search([]) - mails
+        self.assertIn("&amp;access_token=", new_mail.body)


### PR DESCRIPTION
this allows portal users to access mailed attachments