### PR TITLE
[17.0][IMP] queue_job: add Job to recordset ctx

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -756,7 +756,7 @@ class Job:
 
     @property
     def func(self):
-        recordset = self.recordset.with_context(job_uuid=self.uuid)
+        recordset = self.recordset.with_context(job_uuid=self.uuid, job_itself=self)
         return getattr(recordset, self.method_name)
 
     @property

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -5,7 +5,7 @@ from odoo import api, fields, models
 
 from odoo.addons.queue_job.delay import chain
 from odoo.addons.queue_job.exception import RetryableJobError
-from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.job import Job, identity_exact
 
 
 class QueueJob(models.Model):
@@ -138,6 +138,18 @@ class ModelTestQueueJob(models.Model):
             self.delayable().no_description(),
         )
         delayables.delay()
+
+    def child_job_from_ctx_job_uuid(self):
+        self._add_child_job(Job.load(self.env, self.env.context["job_uuid"]))
+
+    def child_job_from_ctx_job_itself(self):
+        self._add_child_job(self.env.context["job_itself"])
+
+    def _add_child_job(self, parent_job):
+        child_job = self.with_delay().testing_method()
+        child_job.add_depends([parent_job])
+        parent_job.store()
+        child_job.store()
 
 
 class ModelTestQueueChannel(models.Model):

--- a/test_queue_job/tests/test_dependencies.py
+++ b/test_queue_job/tests/test_dependencies.py
@@ -5,6 +5,7 @@ import odoo.tests.common as common
 
 from odoo.addons.queue_job.delay import DelayableGraph, chain, group
 from odoo.addons.queue_job.job import PENDING, WAIT_DEPENDENCIES, Job
+from odoo.addons.queue_job.tests.common import trap_jobs
 
 
 class TestJobDependencies(common.TransactionCase):
@@ -125,6 +126,38 @@ class TestJobDependencies(common.TransactionCase):
         # not in the job_a instance, here, we re-read it.
         # In practice, it won't be an issue for the jobrunner.
         self.assertEqual(Job.load(self.env, job_a.uuid).state, PENDING)
+
+    def _test_depends_on_running_job(self, job):
+        """Performs ``job`` and returns jobs spawned by its execution
+
+        Mimics RunJobController._try_perform_job()
+        """
+        job.set_started()
+        job.store()
+        with trap_jobs() as trap:
+            job.perform()
+        job.set_done()
+        job.store()
+        return trap.enqueued_jobs
+
+    def test_depends_on_running_job_from_ctx_job_uuid(self):
+        job = self.env["test.queue.job"].with_delay().child_job_from_ctx_job_uuid()
+        child_jobs = self._test_depends_on_running_job(job)
+        self.assertEqual(len(child_jobs), 1)
+        child_job = child_jobs[0]
+        self.assertEqual({job}, child_job.depends_on)
+        self.assertIsNot(job, tuple(child_job.depends_on)[0])
+        self.assertFalse(job.reverse_depends_on)
+
+    def test_depends_on_running_job_from_ctx_job_itself(self):
+        job = self.env["test.queue.job"].with_delay().child_job_from_ctx_job_itself()
+        child_jobs = self._test_depends_on_running_job(job)
+        self.assertEqual(len(child_jobs), 1)
+        child_job = child_jobs[0]
+        self.assertEqual({job}, child_job.depends_on)
+        self.assertIs(job, tuple(child_job.depends_on)[0])
+        self.assertEqual(job.reverse_depends_on, {child_job})
+        self.assertIs(tuple(job.reverse_depends_on)[0], child_job)
 
     def test_dependency_graph(self):
         job_root = Job(self.method)

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -548,13 +548,14 @@ class TestJobModel(JobCommonCase):
         model.create({}).requeue()
         self.assertEqual(stored.state, PENDING)
 
-    def test_context_uuid(self):
+    def test_context_job_data(self):
         delayable = self.env["test.queue.job"].with_delay()
         test_job = delayable.testing_method(return_context=True)
         result = test_job.perform()
-        key_present = "job_uuid" in result
-        self.assertTrue(key_present)
+        self.assertTrue("job_uuid" in result)
         self.assertEqual(result["job_uuid"], test_job._uuid)
+        self.assertTrue("job_itself" in result)
+        self.assertIs(result["job_itself"], test_job)
 
     def test_override_channel(self):
         delayable = self.env["test.queue.job"].with_delay(channel="root.sub.sub")


### PR DESCRIPTION
Having the UUID is enough for retrieving the original Job instance via ``Job.load(env, uuid)`` and read its attributes. But the returned Job instance is actually a different one than the Job instance that triggered the function, because loading creates a new instance instead. Therefore, operations beside reading the Job attributes will result in unexpected behaviors (for example: dependencies are not stored correctly).

This commit allows retrieving the Job instance from the context itself to make it usable from within the running method.