### PR TITLE
[18.0][FIX] queue_job_cron: _callback method signature has too many parameters 

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -58,14 +58,14 @@ class IrCron(models.Model):
                 )
         return True
 
-    def _callback(self, cron_name, server_action_id, job_id):
-        cron = self.env["ir.cron"].sudo().browse(job_id)
-        if cron.run_as_queue_job:
+    def _callback(self, cron_name, server_action_id):
+        self.ensure_one()
+        if self.run_as_queue_job:
             server_action = self.env["ir.actions.server"].browse(server_action_id)
-            return cron._delay_run_job_as_queue_job(server_action=server_action)
+            return self._delay_run_job_as_queue_job(server_action=server_action)
         else:
             return super()._callback(
-                cron_name=cron_name, server_action_id=server_action_id, job_id=job_id
+                cron_name=cron_name, server_action_id=server_action_id
             )
 
     def _delay_run_job_as_queue_job(self, server_action):

--- a/queue_job_cron/tests/test_queue_job_cron.py
+++ b/queue_job_cron/tests/test_queue_job_cron.py
@@ -58,3 +58,27 @@ class TestQueueJobCron(TransactionCase):
         cron.method_direct_trigger()
         nb_jobs = self.env["queue.job"].search_count([("name", "=", cron.name)])
         self.assertEqual(nb_jobs, 2)
+
+    def test_queue_job_cron_callback(self):
+        nb_partners = self.env["res.partner"].search_count([])
+        nb_jobs = self.env["queue.job"].search_count([])
+        partner_model = self.env.ref("base.model_res_partner")
+        action = self.env["ir.actions.server"].create(
+            {
+                "name": "Queue job cron callback action create partner",
+                "state": "code",
+                "model_id": partner_model.id,
+                "crud_model_id": partner_model.id,
+                "code": "model.name_create('job Cron partner')",
+            }
+        )
+        cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
+        cron._callback("Test queue job cron", action.id)
+        nb_partners_after_cron = self.env["res.partner"].search_count([])
+        self.assertEqual(nb_partners_after_cron, nb_partners + 1)
+        cron.write({"run_as_queue_job": True})
+        cron._callback("Test queue job cron", action.id)
+        nb_partners_after_cron = self.env["res.partner"].search_count([])
+        self.assertEqual(nb_partners_after_cron, nb_partners + 1)
+        nb_jobs_after_cron = self.env["queue.job"].search_count([])
+        self.assertEqual(nb_jobs_after_cron, nb_jobs + 1)


### PR DESCRIPTION
PR to fix this [issue](https://github.com/OCA/queue/issues/770) 

The signature of `_callback`method has changed in 18.0. There is no more `job_id`parameter. 