### PR TITLE
[14.0][IMP] queue_job: cancel job before it retries

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -591,6 +591,17 @@ class Job:
 
         db_record = self.db_record()
         if db_record:
+            # If job was cancelled manually, do not revive it for a retry
+            if (
+                self.retry > 0
+                and db_record.state == CANCELLED
+                and self.state in (PENDING, FAILED)
+            ):
+                self.state = CANCELLED
+                self.date_cancelled = db_record.date_cancelled
+                if not self.result and db_record.result:
+                    self.result = db_record.result
+
             db_record.with_context(_job_edit_sentinel=edit_sentinel).write(
                 self._store_values()
             )

--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -25,7 +25,7 @@
                     />
                     <button
                         name="button_cancelled"
-                        states="pending,enqueued,failed"
+                        states="pending,enqueued,started,failed"
                         class="oe_highlight"
                         string="Cancel job"
                         type="object"

--- a/queue_job/wizards/queue_jobs_to_cancelled.py
+++ b/queue_job/wizards/queue_jobs_to_cancelled.py
@@ -11,7 +11,7 @@ class SetJobsToCancelled(models.TransientModel):
 
     def set_cancelled(self):
         jobs = self.job_ids.filtered(
-            lambda x: x.state in ("pending", "failed", "enqueued")
+            lambda x: x.state in ("pending", "failed", "enqueued", "started")
         )
         jobs.button_cancelled()
         return {"type": "ir.actions.act_window_close"}

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -384,6 +384,84 @@ class TestJobsOnTestingMethod(JobCommonCase):
         job1 = Job.load(self.env, test_job_1.uuid)
         self.assertEqual(job1.identity_key, expected_key)
 
+    def test_job_cancelled_while_started(self):
+        # Job finishes successfully:
+        # if record was set to cancel in the meantime, it is overriden
+        test_job = Job(self.method, max_retries=3)
+        test_job.store()
+        test_job.set_enqueued()
+        test_job.set_started()
+        test_job.store()
+        stored = self.queue_job.search([("uuid", "=", test_job.uuid)])
+        stored.button_cancelled()
+        # Simulate successful job
+        test_job.perform()
+        datetime_path = "odoo.addons.queue_job.job.datetime"
+        with mock.patch(datetime_path, autospec=True) as mock_datetime:
+            mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
+            test_job.set_done("Job ended successfully")
+        self.assertEqual(test_job.state, DONE)
+        self.assertEqual(test_job.retry, 1)
+        test_job.store()
+        self.assertEqual(stored.state, DONE)
+        self.assertEqual(stored.date_cancelled, False)
+        self.assertEqual(stored.date_done, datetime(2015, 3, 15, 16, 41))
+        self.assertEqual(stored.retry, 1)
+        self.assertEqual(stored.result, "Job ended successfully")
+
+    def test_job_cancelled_while_started_not_retried(self):
+        # Job fails with retryable error:
+        # if record was set to cancel in the meantime, it is not retried
+        test_job = Job(self.method, kwargs={"raise_retry": True}, max_retries=3)
+        test_job.store()
+        test_job.set_enqueued()
+        test_job.set_started()
+        test_job.store()
+        stored = self.queue_job.search([("uuid", "=", test_job.uuid)])
+        datetime_path = "odoo.addons.queue_job.job.datetime"
+        with mock.patch(datetime_path, autospec=True) as mock_datetime:
+            mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
+            stored.button_cancelled()
+        # Simulate fail/retry job
+        with self.assertRaises(RetryableJobError) as cm:
+            test_job.perform()
+        test_job.set_pending(result=str(cm.exception), reset_retry=False)
+        self.assertEqual(test_job.state, PENDING)
+        self.assertEqual(test_job.retry, 1)
+        test_job.store()
+        self.assertEqual(stored.state, CANCELLED)
+        self.assertEqual(stored.date_cancelled, datetime(2015, 3, 15, 16, 41))
+        self.assertEqual(stored.date_done, False)
+        self.assertEqual(stored.retry, 1)
+        self.assertEqual(stored.result, "Must be retried later")
+
+    def test_job_cancelled_while_started_failed(self):
+        # Job fails:
+        # if record was set to cancel in the meantime, keep state cancelled
+        test_job = Job(self.method, max_retries=3)
+        test_job.store()
+        test_job.set_enqueued()
+        test_job.set_started()
+        test_job.store()
+        stored = self.queue_job.search([("uuid", "=", test_job.uuid)])
+        datetime_path = "odoo.addons.queue_job.job.datetime"
+        with mock.patch(datetime_path, autospec=True) as mock_datetime:
+            mock_datetime.now.return_value = datetime(2015, 3, 15, 16, 41, 0)
+            stored.button_cancelled()
+        # Simulate failed job
+        test_job.perform()
+        test_job.set_failed(result=False, exc_info="failed test", exc_name="FailedTest")
+        self.assertEqual(test_job.state, FAILED)
+        self.assertEqual(test_job.retry, 1)
+        test_job.store()
+        self.assertEqual(stored.state, CANCELLED)
+        self.assertEqual(stored.date_cancelled, datetime(2015, 3, 15, 16, 41))
+        self.assertEqual(stored.date_done, False)
+        self.assertEqual(stored.retry, 1)
+        self.assertEqual(stored.result, "Cancelled by OdooBot")
+        self.assertEqual(stored.exc_info, "failed test")
+        self.assertEqual(stored.exc_name, "FailedTest")
+
 
 class TestJobs(JobCommonCase):
     """Test jobs on other methods or with different job configuration"""


### PR DESCRIPTION
Use case:
- a job hangs due to some concurrent access in the database, it prevents other job from running
- after some time it fails with retryable error
- it is retried short time after, and it can continue like this for some time
- since the button "Cancel" is not authorized on running jobs, the operator cannot cancel this job

This patch allows to Cancel running jobs:
- job is started, then operator chooses to cancel it (because it already retried 2 times, for example, and is blocking other jobs)
- when button is pressed, job record is set to "Cancelled"
- job will not be interrupted
- if job ends successfully: its state is saved to "Done"
- if it fails with an error, its state stays "Cancelled" and it is not retried