### PR TITLE
[16][FIX] queue_job : replace deprecated invalidate_cache

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -632,7 +632,7 @@ class Job:
     def cancel_dependent_jobs(self):
         sql = self._get_common_dependent_jobs_query()
         self.env.cr.execute(sql, (CANCELLED, self.uuid, CANCELLED, WAIT_DEPENDENCIES))
-        self.env["queue.job"].invalidate_cache(["state"])
+        self.env["queue.job"].invalidate_model(["state"])
 
     def store(self):
         """Store the Job"""


### PR DESCRIPTION
Avoid deprecated warning on job cancelation