### PR TITLE
[18.0][IMP] queue_job: use __slots__ for ChannelJob

### DIFF
--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -173,6 +173,8 @@ class ChannelJob:
 
     """
 
+    __slots__ = ("db_name", "channel", "uuid", "seq", "date_created", "priority", "eta")
+
     def __init__(self, db_name, channel, uuid, seq, date_created, priority, eta):
         self.db_name = db_name
         self.channel = channel


### PR DESCRIPTION
It decreases memory footprint when there's thousands of jobs to prioritize.