### PR TITLE
[18.0][FIX] queue_job: missing slot for __weakref__

### DIFF
--- a/queue_job/jobrunner/channels.py
+++ b/queue_job/jobrunner/channels.py
@@ -173,7 +173,16 @@ class ChannelJob:
 
     """
 
-    __slots__ = ("db_name", "channel", "uuid", "seq", "date_created", "priority", "eta")
+    __slots__ = (
+        "db_name",
+        "channel",
+        "uuid",
+        "seq",
+        "date_created",
+        "priority",
+        "eta",
+        "__weakref__",
+    )
 
     def __init__(self, db_name, channel, uuid, seq, date_created, priority, eta):
         self.db_name = db_name


### PR DESCRIPTION
This PR merge breaks 18.0:
- #778

Since Doctest do not run (#780), we got the error too late.
It's actually the backport to Odoo 14.0 which helped to find it.

@guewen 
Can you review and merge, to fix branch 18.0.

Thanks.