### PR TITLE
[17.0] [FIX] queue_job: cancel job waiting dependencies

### DIFF
--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -25,7 +25,7 @@
                     />
                     <button
                         name="button_cancelled"
-                        invisible="state not in ('pending', 'enqueued', 'failed')"
+                        invisible="state not in ('wait_dependencies', 'pending', 'enqueued', 'failed')"
                         class="oe_highlight"
                         string="Cancel job"
                         type="object"

--- a/queue_job/wizards/queue_jobs_to_cancelled.py
+++ b/queue_job/wizards/queue_jobs_to_cancelled.py
@@ -11,7 +11,7 @@ class SetJobsToCancelled(models.TransientModel):
 
     def set_cancelled(self):
         jobs = self.job_ids.filtered(
-            lambda x: x.state in ("pending", "failed", "enqueued")
+            lambda x: x.state in ("wait_dependencies", "pending", "failed", "enqueued")
         )
         jobs.button_cancelled()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
We should be able to cancel jobs waiting dependencies