### PR TITLE
[14.0][FIX] queue_job: Cannot toggle visibility of ETA column

### DIFF
--- a/queue_job/views/queue_job_views.xml
+++ b/queue_job/views/queue_job_views.xml
@@ -157,7 +157,7 @@
                 <field name="model_name" optional="show" />
                 <field name="state" />
                 <field name="date_created" />
-                <field name="eta" optional="show" />
+                <field name="eta" />
                 <field
                     name="eta"
                     widget="remaining_days"


### PR DESCRIPTION
Since there are 2 "eta" column in the view, the Optional checkbox does not behave correctly.
Easier way to fix it is to remove "optional" on the 1st column. This is partial revert of recent PR:
- #791 

No such issue in 16/17/18 since there is only 1 `"eta"` column for these versions.