### PR TITLE
[18.0][IMP] queue_job: add index for efficient autovacuum

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 from odoo import _, api, exceptions, fields, models
 from odoo.osv import expression
-from odoo.tools import config, html_escape
+from odoo.tools import config, html_escape, index_exists
 
 from odoo.addons.base_sparse_field.models.fields import Serialized
 
@@ -128,15 +128,20 @@ class QueueJob(models.Model):
     worker_pid = fields.Integer(readonly=True)
 
     def init(self):
-        self._cr.execute(
-            "SELECT indexname FROM pg_indexes WHERE indexname = %s ",
-            ("queue_job_identity_key_state_partial_index",),
-        )
-        if not self._cr.fetchone():
+        index_1 = "queue_job_identity_key_state_partial_index"
+        index_2 = "queue_job_channel_date_done_date_created_index"
+        if not index_exists(self._cr, index_1):
+            # Used by Job.job_record_with_same_identity_key
             self._cr.execute(
                 "CREATE INDEX queue_job_identity_key_state_partial_index "
                 "ON queue_job (identity_key) WHERE state in ('pending', "
                 "'enqueued', 'wait_dependencies') AND identity_key IS NOT NULL;"
+            )
+        if not index_exists(self._cr, index_2):
+            # Used by <queue.job>.autovacuum
+            self._cr.execute(
+                "CREATE INDEX queue_job_channel_date_done_date_created_index "
+                "ON queue_job (channel, date_done, date_created);"
             )
 
     @api.depends("dependencies")
@@ -399,6 +404,7 @@ class QueueJob(models.Model):
                         ("date_cancelled", "<=", deadline),
                         ("channel", "=", channel.complete_name),
                     ],
+                    order="date_done, date_created",
                     limit=1000,
                 )
                 if jobs:


### PR DESCRIPTION
This query was part of the slowest.

Before:
```sql
# EXPLAIN ANALYZE
SELECT id FROM "queue_job"
 WHERE (("date_done" <= '2025-07-01' OR "date_cancelled" <= '2025-07-01') AND "channel" = 'root.custom.purchase')
 ORDER BY "date_created" DESC, "date_done" DESC LIMIT 1000;
                                                                                QUERY PLAN                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=212724.34..212841.01 rows=1000 width=20) (actual time=1949.277..1966.346 rows=1000 loops=1)
   ->  Gather Merge  (cost=212724.34..220532.68 rows=66924 width=20) (actual time=1939.068..1956.102 rows=1000 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=211724.32..211807.97 rows=33462 width=20) (actual time=1880.715..1880.798 rows=779 loops=3)
               Sort Key: date_created DESC, date_done DESC
               Sort Method: top-N heapsort  Memory: 179kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 180kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 183kB
               ->  Parallel Bitmap Heap Scan on queue_job  (cost=944.61..209889.63 rows=33462 width=20) (actual time=16.823..1873.439 rows=27435 loops=3)
                     Recheck Cond: ((channel)::text = 'root.custom.purchase'::text)
                     Rows Removed by Index Recheck: 51603
                     Filter: ((date_done <= '2025-07-01 00:00:00'::timestamp without time zone) OR (date_cancelled <= '2025-07-01 00:00:00'::timestamp without time zone))
                     Rows Removed by Filter: 224
                     Heap Blocks: exact=13666 lossy=12625
                     ->  Bitmap Index Scan on queue_job_channel_index  (cost=0.00..924.54 rows=83748 width=0) (actual time=13.932..13.932 rows=82979 loops=1)
                           Index Cond: ((channel)::text = 'root.custom.purchase'::text)
 Planning Time: 1.395 ms
 JIT:
   Functions: 19
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 4.315 ms, Inlining 0.000 ms, Optimization 3.396 ms, Emission 37.965 ms, Total 45.676 ms
 Execution Time: 1968.386 ms
(23 rows)
```
----

After:
```sql
# EXPLAIN ANALYZE
SELECT id FROM "queue_job"
 WHERE (("date_done" <= '2025-07-01' OR "date_cancelled" <= '2025-07-01') AND "channel" = 'root.custom.purchase')
 ORDER BY "date_created" DESC, "date_done" DESC LIMIT 1000;

                                                                                                       QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..66770.92 rows=1000 width=20) (actual time=0.750..93.965 rows=1000 loops=1)
   ->  Index Scan Backward using queue_job_date_created_date_done_index on queue_job  (cost=0.43..5362271.99 rows=80309 width=20) (actual time=0.748..93.895 rows=1000 loops=1)
         Filter: (((channel)::text = 'root.custom.purchase'::text) AND ((date_done <= '2025-07-01 00:00:00'::timestamp without time zone) OR (date_cancelled <= '2025-07-01 00:00:00'::timestamp without time zone)))
         Rows Removed by Filter: 40686
 Planning Time: 0.312 ms
 Execution Time: 94.057 ms
(6 rows)
```