### PR TITLE
[FIX] queue_job: prevent conflict w/ TestOverrides:test_creates

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -235,13 +235,8 @@ class QueueJob(models.Model):
             record.graph_jobs_count = count_per_graph_uuid.get(record.graph_uuid) or 0
 
     @api.model_create_multi
+    @api.private
     def create(self, vals_list):
-        if self.env.context.get("_job_edit_sentinel") is not self.EDIT_SENTINEL:
-            # Prevent to create a queue.job record "raw" from RPC.
-            # ``with_delay()`` must be used.
-            raise exceptions.AccessError(
-                _("Queue jobs must be created by calling 'with_delay()'.")
-            )
         return super(
             QueueJob,
             self.with_context(mail_create_nolog=True, mail_create_nosubscribe=True),

--- a/queue_job/tests/test_queue_job_protected_write.py
+++ b/queue_job/tests/test_queue_job_protected_write.py
@@ -3,15 +3,33 @@
 
 from odoo import exceptions
 from odoo.tests import common
+from odoo.tools import mute_logger
+
+
+class TestJobCreatePrivate(common.HttpCase):
+    def test_create_error(self):
+        self.authenticate("admin", "admin")
+        with self.assertRaises(common.JsonRpcException) as cm, mute_logger("odoo.http"):
+            self.make_jsonrpc_request(
+                "/web/dataset/call_kw",
+                params={
+                    "model": "queue.job",
+                    "method": "create",
+                    "args": [],
+                    "kwargs": {
+                        "method_name": "write",
+                        "model_name": "res.partner",
+                        "uuid": "test",
+                    },
+                },
+                headers={
+                    "Cookie": f"session_id={self.session.sid};",
+                },
+            )
+        self.assertEqual("odoo.exceptions.AccessError", str(cm.exception))
 
 
 class TestJobWriteProtected(common.TransactionCase):
-    def test_create_error(self):
-        with self.assertRaises(exceptions.AccessError):
-            self.env["queue.job"].create(
-                {"uuid": "test", "model_name": "res.partner", "method_name": "write"}
-            )
-
     def test_write_protected_field_error(self):
         job_ = self.env["res.partner"].with_delay().create({"name": "test"})
         db_job = job_.db_record()


### PR DESCRIPTION
This prevents TestOverrides.test_creates from failing in the Odoo `base` module due to the sentinel protections taking effect even for local create invocations.

Fixes #727 