### PR TITLE
[18.0] queue_job: fix references to tree views

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -486,7 +486,7 @@ class QueueJob(models.Model):
             action.update(
                 {
                     "name": _("Related Records"),
-                    "view_mode": "tree,form",
+                    "view_mode": "list,form",
                     "domain": [("id", "in", records.ids)],
                 }
             )

--- a/test_queue_job/tests/test_related_actions.py
+++ b/test_queue_job/tests/test_related_actions.py
@@ -89,7 +89,7 @@ class TestRelatedAction(common.TransactionCase):
             "domain": [("id", "in", self.records.ids)],
             "res_model": self.record._name,
             "type": "ir.actions.act_window",
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
         }
         self.assertEqual(job_.related_action(), expected)
 


### PR DESCRIPTION
Fix Uncaught Promise > View types not defined tree found in act_window action undefined.