### PR TITLE
Increase ideal timeout value to 5 seconds.

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -245,7 +245,8 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
                 auth = (user, password)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = requests.get(url, timeout=1, auth=auth)
+            # Set timeout to 5 seconds to avoid any network latency related error/request failure.
+            response = requests.get(url, timeout=5, auth=auth)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error


### PR DESCRIPTION
It is good to increase ideal timeout value to 5 seconds to avoid any network latency related error/request failure.