### PR TITLE
[18.0][IMP] queue_job: avoid deprecation warning about `datetime.datetime.utcnow()` in `_odoo_now()`

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -139,7 +139,6 @@ Caveat
        of running Odoo is obviously not for production purposes.
 """
 
-import datetime
 import logging
 import os
 import selectors
@@ -181,15 +180,10 @@ def _channels():
     )
 
 
-def _datetime_to_epoch(dt):
+def _odoo_now():
     # important: this must return the same as postgresql
     # EXTRACT(EPOCH FROM TIMESTAMP dt)
-    return (dt - datetime.datetime(1970, 1, 1)).total_seconds()
-
-
-def _odoo_now():
-    dt = datetime.datetime.utcnow()
-    return _datetime_to_epoch(dt)
+    return time.time()
 
 
 def _connection_info_for(db_name):


### PR DESCRIPTION
`datetime.datetime.utcnow()` is now deprecated and should be replaced by `datetime.datetime.now()` (optional TZ parameter).
As the original `_odoo_now()` doesn't contain the Timezone, the parameter `datetime.UTC` is not added into this improvement to stay a `naive datetime`.

The purpose of `_odoo_now()` is to have the current datetime in UTC timezone but staying `naive datetime`.

https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

https://docs.python.org/3/whatsnew/3.12.html#:~:text=datetime%3A%20datetime,gh%2D103857.)

**Original warning:**
<img width="1502" height="414" alt="image" src="https://github.com/user-attachments/assets/44975acd-5a16-45a4-8638-bd9340829fb2" />


