### PR TITLE
[FIX] queue_job_cron_jobrunner: use priority to select job

### DIFF
--- a/queue_job_cron_jobrunner/models/queue_job.py
+++ b/queue_job_cron_jobrunner/models/queue_job.py
@@ -36,7 +36,7 @@ class QueueJob(models.Model):
             FROM queue_job
             WHERE state = 'pending'
             AND (eta IS NULL OR eta <= (now() AT TIME ZONE 'UTC'))
-            ORDER BY date_created DESC
+            ORDER BY priority, date_created
             LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED
             """
         )
@@ -55,7 +55,7 @@ class QueueJob(models.Model):
         #       while the job is processing. However, doing this will release the
         #       lock on the db, so we need to find another way.
         # if commit:
-        #     self.flush()
+        #     self.env.flush_all()
         #     self.env.cr.commit()
 
         # Actual processing


### PR DESCRIPTION
[FIX] queue_job_cron_jobrunner: use priority to select job
* use FIFO, firt createad job will be treat first
* if priority are different it take the precedent

Yet we are not using channel priority into account.

Note:  FIX has already been applied to branch 17.0.
Ref: https://github.com/OCA/queue/commit/f8fcceba13d9e78fea82bcca08a648f4b23c6664