### PR TITLE
[18.0] [FIX] queue_job: fix exception msg handling

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -156,7 +156,9 @@ class RunJobController(http.Controller):
         exception_name = orig_exception.__class__.__name__
         if hasattr(orig_exception, "__module__"):
             exception_name = orig_exception.__module__ + "." + exception_name
-        exc_message = getattr(orig_exception, "name", str(orig_exception))
+        exc_message = (
+            orig_exception.args[0] if orig_exception.args else str(orig_exception)
+        )
         return {
             "exc_info": traceback_txt,
             "exc_name": exception_name,

--- a/queue_job/tests/__init__.py
+++ b/queue_job/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_run_rob_controller
 from . import test_runner_channels
 from . import test_runner_runner
 from . import test_delayable

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -1,0 +1,17 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+from ..controllers.main import RunJobController
+from ..job import Job
+
+
+class TestRunJobController(TransactionCase):
+    def test_get_failure_values(self):
+        method = self.env["res.users"].mapped
+        job = Job(method)
+        ctrl = RunJobController()
+        rslt = ctrl._get_failure_values(job, "info", Exception("zero", "one"))
+        self.assertEqual(
+            rslt, {"exc_info": "info", "exc_name": "Exception", "exc_message": "zero"}
+        )


### PR DESCRIPTION
Forward port of #824 (16.0) 

17.0 PR : #825 

'name' attributes for odoo's exception has been deprecated and produces a warning message. This commit fixes the behavior