### PR TITLE
[19.0] [MIG] queue_job_cron: migrate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ exclude: |
   # NOT INSTALLABLE ADDONS
   ^base_import_async/|
   ^queue_job_batch/|
-  ^queue_job_cron/|
   ^queue_job_cron_jobrunner/|
   ^queue_job_subscribe/|
   ^test_queue_job_batch/|

--- a/queue_job_cron/README.rst
+++ b/queue_job_cron/README.rst
@@ -21,13 +21,13 @@ Scheduled Actions as Queue Jobs
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github
-    :target: https://github.com/OCA/queue/tree/18.0/queue_job_cron
+    :target: https://github.com/OCA/queue/tree/19.0/queue_job_cron
     :alt: OCA/queue
 .. |badge4| image:: https://img.shields.io/badge/weblate-Translate%20me-F47D42.png
-    :target: https://translation.odoo-community.org/projects/queue-18-0/queue-18-0-queue_job_cron
+    :target: https://translation.odoo-community.org/projects/queue-19-0/queue-19-0-queue_job_cron
     :alt: Translate me on Weblate
 .. |badge5| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/builds?repo=OCA/queue&target_branch=18.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/queue&target_branch=19.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
@@ -89,7 +89,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/queue/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron%0Aversion:%2019.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -128,6 +128,6 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-This module is part of the `OCA/queue <https://github.com/OCA/queue/tree/18.0/queue_job_cron>`_ project on GitHub.
+This module is part of the `OCA/queue <https://github.com/OCA/queue/tree/19.0/queue_job_cron>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/queue_job_cron/__manifest__.py
+++ b/queue_job_cron/__manifest__.py
@@ -3,12 +3,12 @@
 
 {
     "name": "Scheduled Actions as Queue Jobs",
-    "version": "18.0.1.1.1",
+    "version": "19.0.1.0.0",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/queue",
     "license": "AGPL-3",
     "category": "Generic Modules",
     "depends": ["queue_job"],
     "data": ["data/data.xml", "views/ir_cron_view.xml"],
-    "installable": False,
+    "installable": True,
 }

--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -1,12 +1,8 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-import logging
-
 from odoo import api, fields, models
 
 from odoo.addons.queue_job.job import identity_exact
-
-_logger = logging.getLogger(__name__)
 
 
 class IrCron(models.Model):

--- a/queue_job_cron/static/description/index.html
+++ b/queue_job_cron/static/description/index.html
@@ -374,7 +374,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:61571266d30481c36fe1d1751209760e580f0fdd528d8a39b9610f37a442c920
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/queue/tree/18.0/queue_job_cron"><img alt="OCA/queue" src="https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/queue-18-0/queue-18-0-queue_job_cron"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/queue&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/queue/tree/19.0/queue_job_cron"><img alt="OCA/queue" src="https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/queue-19-0/queue-19-0-queue_job_cron"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/queue&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of queue_job and allows to run an
 Odoo cron as a queue job.</p>
 <p><strong>Table of contents</strong></p>
@@ -445,7 +445,7 @@ disable this restriction when run as a queue job.
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/queue/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron%0Aversion:%2019.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -479,7 +479,7 @@ by Camptocamp.</p>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>This module is part of the <a class="reference external" href="https://github.com/OCA/queue/tree/18.0/queue_job_cron">OCA/queue</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/OCA/queue/tree/19.0/queue_job_cron">OCA/queue</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>
 </div>

--- a/queue_job_cron/tests/test_queue_job_cron.py
+++ b/queue_job_cron/tests/test_queue_job_cron.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from odoo.tests.common import TransactionCase
 
 
@@ -8,20 +9,23 @@ class TestQueueJobCron(TransactionCase):
         super().setUp()
 
     def test_queue_job_cron(self):
-        QueueJob = self.env["queue.job"]
         default_channel = self.env.ref("queue_job_cron.channel_root_ir_cron")
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
         self.assertFalse(cron.run_as_queue_job)
 
-        cron.method_direct_trigger()
-        nb_jobs = QueueJob.search_count([("name", "=", cron.name)])
+        # Use core helper enter_registry_test_mode so method_direct_trigger
+        # runs safely under 19.0 test harness (avoids cross-cursor
+        # visibility/locking quirks during tests).
+        with self.enter_registry_test_mode():
+            cron.method_direct_trigger()
+        nb_jobs = self.env["queue.job"].search_count([("name", "=", cron.name)])
         self.assertEqual(nb_jobs, 0)
 
+        # Enable run_as_queue_job and trigger via method_direct_trigger
         cron.write({"run_as_queue_job": True, "channel_id": default_channel.id})
-
-        cron.method_direct_trigger()
-        qjob = QueueJob.search([("name", "=", cron.name)])
-
+        with self.enter_registry_test_mode():
+            cron.method_direct_trigger()
+        qjob = self.env["queue.job"].search([("name", "=", cron.name)])
         self.assertTrue(qjob)
         self.assertEqual(qjob.name, cron.name)
         self.assertEqual(qjob.priority, cron.priority)
@@ -32,8 +36,13 @@ class TestQueueJobCron(TransactionCase):
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
         default_channel = self.env.ref("queue_job_cron.channel_root_ir_cron")
         self.assertFalse(cron.run_as_queue_job)
-        cron.write({"run_as_queue_job": True})
-        self.assertEqual(cron.channel_id.id, default_channel.id)
+        # Write + assert in a fresh cursor to avoid ir.cron row lock
+        # serialization under 19.0 when scheduler touches it.
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            cron2 = env2["ir.cron"].browse(cron.id)
+            cron2.write({"run_as_queue_job": True})
+            self.assertEqual(cron2.channel_id.id, default_channel.id)
 
     def test_queue_job_cron_run(self):
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
@@ -43,42 +52,81 @@ class TestQueueJobCron(TransactionCase):
     def test_queue_job_no_parallelism(self):
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
         default_channel = self.env.ref("queue_job_cron.channel_root_ir_cron")
-        cron.write(
-            {
-                "no_parallel_queue_job_run": True,
-                "run_as_queue_job": True,
-                "channel_id": default_channel.id,
-            }
-        )
-        cron.method_direct_trigger()
-        cron.method_direct_trigger()
-        nb_jobs = self.env["queue.job"].search_count([("name", "=", cron.name)])
-        self.assertEqual(nb_jobs, 1)
-        cron.no_parallel_queue_job_run = False
-        cron.method_direct_trigger()
-        nb_jobs = self.env["queue.job"].search_count([("name", "=", cron.name)])
-        self.assertEqual(nb_jobs, 2)
+        # Configure + enqueue in a fresh cursor to avoid serialization
+        # conflicts; call _delay_run_job_as_queue_job twice to exercise
+        # identity-based dedup under no_parallel setting.
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            cron2 = env2["ir.cron"].browse(cron.id)
+            cron2.write(
+                {
+                    "no_parallel_queue_job_run": True,
+                    "run_as_queue_job": True,
+                    "channel_id": default_channel.id,
+                }
+            )
+            # Enqueue twice via the queue path; identity prevents duplicates
+            cron2._delay_run_job_as_queue_job(server_action=cron2.ir_actions_server_id)
+            cron2._delay_run_job_as_queue_job(server_action=cron2.ir_actions_server_id)
+            nb_jobs2 = env2["queue.job"].search_count([("name", "=", cron2.name)])
+            self.assertEqual(nb_jobs2, 1)
+            # Allow parallelism and enqueue once more; count increases
+            cron2.write({"no_parallel_queue_job_run": False})
+            cron2._delay_run_job_as_queue_job(server_action=cron2.ir_actions_server_id)
+            nb_jobs2 = env2["queue.job"].search_count([("name", "=", cron2.name)])
+            self.assertEqual(nb_jobs2, 2)
+        # Cleanup: enqueues above happen in a committed cursor; remove them to
+        # avoid leaking pending jobs into subsequent modules (e.g. jobrunner).
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            env2["queue.job"].sudo().search([("name", "=", cron.name)]).unlink()
 
     def test_queue_job_cron_callback(self):
-        nb_partners = self.env["res.partner"].search_count([])
-        nb_jobs = self.env["queue.job"].search_count([])
-        partner_model = self.env.ref("base.model_res_partner")
-        action = self.env["ir.actions.server"].create(
-            {
-                "name": "Queue job cron callback action create partner",
-                "state": "code",
-                "model_id": partner_model.id,
-                "crud_model_id": partner_model.id,
-                "code": "model.name_create('job Cron partner')",
-            }
-        )
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
-        cron._callback("Test queue job cron", action.id)
-        nb_partners_after_cron = self.env["res.partner"].search_count([])
-        self.assertEqual(nb_partners_after_cron, nb_partners + 1)
-        cron.write({"run_as_queue_job": True})
-        cron._callback("Test queue job cron", action.id)
-        nb_partners_after_cron = self.env["res.partner"].search_count([])
-        self.assertEqual(nb_partners_after_cron, nb_partners + 1)
-        nb_jobs_after_cron = self.env["queue.job"].search_count([])
-        self.assertEqual(nb_jobs_after_cron, nb_jobs + 1)
+        # Run _callback in a separate cursor because core _callback
+        # commits/rollbacks; main test cursor forbids it. Assert within the
+        # same cursor for deterministic visibility.
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            count_before = env2["res.partner"].search_count([])
+            partner_model = env2.ref("base.model_res_partner")
+            action = env2["ir.actions.server"].create(
+                {
+                    "name": "Queue job cron callback action create partner",
+                    "state": "code",
+                    "model_id": partner_model.id,
+                    "crud_model_id": partner_model.id,
+                    "code": "model.name_create('job Cron partner')",
+                }
+            )
+            env2["ir.cron"].browse(cron.id)._callback("Test queue job cron", action.id)
+            partners_after = env2["res.partner"].search_count([])
+            self.assertEqual(partners_after, count_before + 1)
+        # Phase 2: enable run_as_queue_job and ensure callback enqueues a job
+        # (not synchronous); use a separate cursor and assert within it.
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            env2["ir.cron"].browse(cron.id).write({"run_as_queue_job": True})
+            count_before = env2["res.partner"].search_count([])
+            jobs_before = env2["queue.job"].search_count([])
+            partner_model = env2.ref("base.model_res_partner")
+            action = env2["ir.actions.server"].create(
+                {
+                    "name": "Queue job cron callback action create partner",
+                    "state": "code",
+                    "model_id": partner_model.id,
+                    "crud_model_id": partner_model.id,
+                    "code": "model.name_create('job Cron partner')",
+                }
+            )
+            env2["ir.cron"].browse(cron.id)._callback("Test queue job cron", action.id)
+            partners_after = env2["res.partner"].search_count([])
+            jobs_after = env2["queue.job"].search_count([])
+            self.assertEqual(partners_after, count_before)
+            self.assertEqual(jobs_after, jobs_before + 1)
+        # Cleanup: ensure no leakage across tests when using a shared DB name
+        with self.registry.cursor() as cr:
+            env2 = self.env(cr=cr)
+            cron2 = env2["ir.cron"].browse(cron.id)
+            jobs = env2["queue.job"].sudo().search([("name", "=", cron2.name)])
+            jobs.unlink()


### PR DESCRIPTION
Scope
- queue_job_cron, queue_job_cron_jobrunner

Depends on
- [x] https://github.com/OCA/queue/pull/840

Summary
- Migrate to Odoo 19; tests included. No functional changes beyond compatibility.

Temporary references
- test-requirements.txt adds temporary dependencies to the base PR for CI/runboat.
  This will be removed once the base PR merges.

Pre-commit
- Ran locally; auto-fixes committed.

Tests
- CI will run the suite using the referenced base PR. Local isolated runs may skip pieces if queue_job is absent.