### PR TITLE
[19.0] [MIG] queue_job_cron_jobrunner: migrate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ exclude: |
   ^queue_job/|
   ^queue_job_batch/|
   ^queue_job_cron/|
-  ^queue_job_cron_jobrunner/|
   ^queue_job_subscribe/|
   ^test_queue_job/|
   ^test_queue_job_batch/|

--- a/queue_job_cron_jobrunner/README.rst
+++ b/queue_job_cron_jobrunner/README.rst
@@ -21,13 +21,13 @@ Queue Job Cron Jobrunner
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github
-    :target: https://github.com/OCA/queue/tree/18.0/queue_job_cron_jobrunner
+    :target: https://github.com/OCA/queue/tree/19.0/queue_job_cron_jobrunner
     :alt: OCA/queue
 .. |badge4| image:: https://img.shields.io/badge/weblate-Translate%20me-F47D42.png
-    :target: https://translation.odoo-community.org/projects/queue-18-0/queue-18-0-queue_job_cron_jobrunner
+    :target: https://translation.odoo-community.org/projects/queue-19-0/queue-19-0-queue_job_cron_jobrunner
     :alt: Translate me on Weblate
 .. |badge5| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/builds?repo=OCA/queue&target_branch=18.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/queue&target_branch=19.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
@@ -102,7 +102,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/queue/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron_jobrunner%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron_jobrunner%0Aversion:%2019.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -142,6 +142,6 @@ Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
 |maintainer-ivantodorovich| 
 
-This module is part of the `OCA/queue <https://github.com/OCA/queue/tree/18.0/queue_job_cron_jobrunner>`_ project on GitHub.
+This module is part of the `OCA/queue <https://github.com/OCA/queue/tree/19.0/queue_job_cron_jobrunner>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/queue_job_cron_jobrunner/__manifest__.py
+++ b/queue_job_cron_jobrunner/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Queue Job Cron Jobrunner",
     "summary": "Run jobs without a dedicated JobRunner",
-    "version": "18.0.1.0.1",
+    "version": "19.0.1.0.0",
     "development_status": "Alpha",
     "author": "Camptocamp SA, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
@@ -13,5 +13,5 @@
         "data/ir_cron.xml",
         "views/ir_cron.xml",
     ],
-    "installable": False,
+    "installable": True,
 }

--- a/queue_job_cron_jobrunner/static/description/index.html
+++ b/queue_job_cron_jobrunner/static/description/index.html
@@ -374,7 +374,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:3c8052bb9647ac1c2222b7bbe43133884ab314534ef09686a3aef58e6b38f712
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/queue/tree/18.0/queue_job_cron_jobrunner"><img alt="OCA/queue" src="https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/queue-18-0/queue-18-0-queue_job_cron_jobrunner"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/queue&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/queue/tree/19.0/queue_job_cron_jobrunner"><img alt="OCA/queue" src="https://img.shields.io/badge/github-OCA%2Fqueue-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/queue-19-0/queue-19-0-queue_job_cron_jobrunner"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/queue&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module implements a simple <tt class="docutils literal">queue.job</tt> runner using <tt class="docutils literal">ir.cron</tt>
 triggers.</p>
 <p>It’s meant to be used on environments where the regular job runner can’t
@@ -446,7 +446,7 @@ until you have as much records as cron workers.</li>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/queue/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron_jobrunner%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/OCA/queue/issues/new?body=module:%20queue_job_cron_jobrunner%0Aversion:%2019.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -480,7 +480,7 @@ mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
 <p><a class="reference external image-reference" href="https://github.com/ivantodorovich"><img alt="ivantodorovich" src="https://github.com/ivantodorovich.png?size=40px" /></a></p>
-<p>This module is part of the <a class="reference external" href="https://github.com/OCA/queue/tree/18.0/queue_job_cron_jobrunner">OCA/queue</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/OCA/queue/tree/19.0/queue_job_cron_jobrunner">OCA/queue</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# generated from manifests external_dependencies
-requests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+odoo-addon-queue_job @ git+https://github.com/OCA/queue.git@refs/pull/840/head#subdirectory=queue_job
+odoo-addon-test_queue_job @ git+https://github.com/OCA/queue.git@refs/pull/840/head#subdirectory=test_queue_job


### PR DESCRIPTION
Scope
- queue_job_cron_jobrunner

Depends on
- [ ] https://github.com/OCA/queue/pull/840

Summary
- Migrate to Odoo 19; no functional changes beyond compatibility.

Temporary references
- test-requirements.txt adds temporary dependencies to the base PR for CI/runboat.
  This will be removed once the base PR merges.

Pre-commit
- Ran locally; auto-fixes committed.

Tests
- No dedicated tests for this addon; CI will still validate packaging and installability with queue_job from PR 840.