### PR TITLE
[18.0][IMP] queue_job: requeue orphaned jobs

### DIFF
--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -378,6 +378,35 @@ class Database:
             RETURNING uuid
             """
 
+    def _query_requeue_orphaned_jobs(self):
+        """Query to requeue jobs stuck in 'enqueued' state without a lock.
+
+        This handles the edge case where the runner marks a job as 'enqueued'
+        but the HTTP request to start the job never reaches the Odoo server
+        (e.g., due to server shutdown/crash between setting enqueued and
+        the controller receiving the request). These jobs have no lock record
+        because set_started() was never called, so they are invisible to
+        _query_requeue_dead_jobs().
+        """
+        return """
+            UPDATE
+                queue_job
+            SET
+                state='pending'
+            WHERE
+                state = 'enqueued'
+                AND date_enqueued < (now() AT TIME ZONE 'utc' - INTERVAL '10 sec')
+                AND NOT EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        queue_job_lock
+                    WHERE
+                        queue_job_id = queue_job.id
+                )
+            RETURNING uuid
+            """
+
     def requeue_dead_jobs(self):
         """
         Set started and enqueued jobs but not locked to pending
@@ -405,6 +434,14 @@ class Database:
 
             for (uuid,) in cr.fetchall():
                 _logger.warning("Re-queued dead job with uuid: %s", uuid)
+
+            # Requeue orphaned jobs (enqueued but never started, no lock)
+            query = self._query_requeue_orphaned_jobs()
+            cr.execute(query)
+            for (uuid,) in cr.fetchall():
+                _logger.warning(
+                    "Re-queued orphaned job (enqueued without lock) with uuid: %s", uuid
+                )
 
 
 class QueueJobRunner:

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -357,52 +357,26 @@ class Database:
                         ELSE exc_info
                     END)
             WHERE
-                id in (
-                    SELECT
-                        queue_job_id
-                    FROM
-                        queue_job_lock
-                    WHERE
-                        queue_job_id in (
-                            SELECT
-                                id
-                            FROM
-                                queue_job
-                            WHERE
-                                state IN ('enqueued','started')
-                                AND date_enqueued <
-                                (now() AT TIME ZONE 'utc' - INTERVAL '10 sec')
-                        )
-                    FOR UPDATE SKIP LOCKED
-                )
-            RETURNING uuid
-            """
-
-    def _query_requeue_orphaned_jobs(self):
-        """Query to requeue jobs stuck in 'enqueued' state without a lock.
-
-        This handles the edge case where the runner marks a job as 'enqueued'
-        but the HTTP request to start the job never reaches the Odoo server
-        (e.g., due to server shutdown/crash between setting enqueued and
-        the controller receiving the request). These jobs have no lock record
-        because set_started() was never called, so they are invisible to
-        _query_requeue_dead_jobs().
-        """
-        return """
-            UPDATE
-                queue_job
-            SET
-                state='pending'
-            WHERE
-                state = 'enqueued'
+                state IN ('enqueued','started')
                 AND date_enqueued < (now() AT TIME ZONE 'utc' - INTERVAL '10 sec')
-                AND NOT EXISTS (
-                    SELECT
-                        1
-                    FROM
-                        queue_job_lock
-                    WHERE
-                        queue_job_id = queue_job.id
+                AND (
+                    id in (
+                        SELECT
+                            queue_job_id
+                        FROM
+                            queue_job_lock
+                        WHERE
+                            queue_job_lock.queue_job_id = queue_job.id
+                        FOR UPDATE SKIP LOCKED
+                    )
+                    OR NOT EXISTS (
+                        SELECT
+                            1
+                        FROM
+                            queue_job_lock
+                        WHERE
+                            queue_job_lock.queue_job_id = queue_job.id
+                    )
                 )
             RETURNING uuid
             """
@@ -425,6 +399,12 @@ class Database:
         However, when the Odoo server crashes or is otherwise force-stopped,
         running jobs are interrupted while the runner has no chance to know
         they have been aborted.
+
+        This also handles orphaned jobs (enqueued but never started, no lock).
+        This edge case occurs when the runner marks a job as 'enqueued'
+        but the HTTP request to start the job never reaches the Odoo server
+        (e.g., due to server shutdown/crash between setting enqueued and
+        the controller receiving the request).
         """
 
         with closing(self.conn.cursor()) as cr:
@@ -434,14 +414,6 @@ class Database:
 
             for (uuid,) in cr.fetchall():
                 _logger.warning("Re-queued dead job with uuid: %s", uuid)
-
-            # Requeue orphaned jobs (enqueued but never started, no lock)
-            query = self._query_requeue_orphaned_jobs()
-            cr.execute(query)
-            for (uuid,) in cr.fetchall():
-                _logger.warning(
-                    "Re-queued orphaned job (enqueued without lock) with uuid: %s", uuid
-                )
 
 
 class QueueJobRunner:

--- a/test_queue_job/tests/test_requeue_dead_job.py
+++ b/test_queue_job/tests/test_requeue_dead_job.py
@@ -99,3 +99,25 @@ class TestRequeueDeadJob(JobCommonCase):
 
         uuids_requeued = self.env.cr.fetchall()
         self.assertTrue(queue_job.uuid in j[0] for j in uuids_requeued)
+
+    def test_requeue_orphaned_jobs(self):
+        queue_job = self._get_demo_job("test_enqueued_job")
+        job_obj = Job.load(self.env, queue_job.uuid)
+
+        # Only enqueued job, don't set it to started to simulate the scenario
+        # that system shutdown before job is starting
+        job_obj.set_enqueued()
+        job_obj.date_enqueued = datetime.now() - timedelta(minutes=1)
+        job_obj.store()
+
+        # job ins't actually picked up by the first requeue attempt
+        query = Database(self.env.cr.dbname)._query_requeue_dead_jobs()
+        self.env.cr.execute(query)
+        uuids_requeued = self.env.cr.fetchall()
+        self.assertFalse(uuids_requeued)
+
+        # job is picked up by the 2nd requeue attempt
+        query = Database(self.env.cr.dbname)._query_requeue_orphaned_jobs()
+        self.env.cr.execute(query)
+        uuids_requeued = self.env.cr.fetchall()
+        self.assertTrue(queue_job.uuid in j[0] for j in uuids_requeued)

--- a/test_queue_job/tests/test_requeue_dead_job.py
+++ b/test_queue_job/tests/test_requeue_dead_job.py
@@ -110,14 +110,8 @@ class TestRequeueDeadJob(JobCommonCase):
         job_obj.date_enqueued = datetime.now() - timedelta(minutes=1)
         job_obj.store()
 
-        # job ins't actually picked up by the first requeue attempt
+        # job is now picked up by the requeue query (which includes orphaned jobs)
         query = Database(self.env.cr.dbname)._query_requeue_dead_jobs()
-        self.env.cr.execute(query)
-        uuids_requeued = self.env.cr.fetchall()
-        self.assertFalse(uuids_requeued)
-
-        # job is picked up by the 2nd requeue attempt
-        query = Database(self.env.cr.dbname)._query_requeue_orphaned_jobs()
         self.env.cr.execute(query)
         uuids_requeued = self.env.cr.fetchall()
         self.assertTrue(queue_job.uuid in j[0] for j in uuids_requeued)


### PR DESCRIPTION
This pr add a secondary attempt to requeue "orphaned jobs" where it stucks in enqueued, not yet make it to queue_job_lock and selecting jobs after db initialization also misses it. Even a server restart would not unblock the job.

This is most likely due to server being shutdown or crash during job enqueue. Manually requeue the job on UI make everything running again.