### PR TITLE
[MIG] Odoo 19.0 has removed config.misc and config.get_misc()

### DIFF
--- a/queue_job/jobrunner/__init__.py
+++ b/queue_job/jobrunner/__init__.py
@@ -4,6 +4,7 @@
 
 import logging
 from threading import Thread
+from configparser import ConfigParser
 import time
 
 from odoo.service import server
@@ -17,7 +18,13 @@ try:
     else:
         queue_job_config = {}
 except ImportError:
-    queue_job_config = config.misc.get("queue_job", {})
+
+    parser = ConfigParser()
+    parser.read(config["config"])
+    if parser.has_section("queue_job"):
+        queue_job_config = parser["queue_job"]
+    else:
+        queue_job_config = {}
 
 
 from .runner import QueueJobRunner, _channels


### PR DESCRIPTION
Odoo 19+ ignores non [options] sections. Reparse the configuration with ConfigParser so that existing rc files can be kept