### PR TITLE
[18.0][IMP] queue_job: add job_duration parameter to test job

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -177,6 +177,7 @@ class RunJobController(http.Controller):
         description="Test job",
         size=1,
         failure_rate=0,
+        job_duration=0,
     ):
         if not http.request.env.user.has_group("base.group_erp_manager"):
             raise Forbidden(_("Access Denied"))
@@ -186,6 +187,12 @@ class RunJobController(http.Controller):
                 failure_rate = float(failure_rate)
             except (ValueError, TypeError):
                 failure_rate = 0
+
+        if job_duration is not None:
+            try:
+                job_duration = float(job_duration)
+            except (ValueError, TypeError):
+                job_duration = 0
 
         if not (0 <= failure_rate <= 1):
             raise BadRequest("failure_rate must be between 0 and 1")
@@ -215,6 +222,7 @@ class RunJobController(http.Controller):
                 channel=channel,
                 description=description,
                 failure_rate=failure_rate,
+                job_duration=job_duration,
             )
 
         if size > 1:
@@ -225,6 +233,7 @@ class RunJobController(http.Controller):
                 channel=channel,
                 description=description,
                 failure_rate=failure_rate,
+                job_duration=job_duration,
             )
         return ""
 
@@ -236,6 +245,7 @@ class RunJobController(http.Controller):
         description="Test job",
         size=1,
         failure_rate=0,
+        job_duration=0,
     ):
         delayed = (
             http.request.env["queue.job"]
@@ -245,7 +255,7 @@ class RunJobController(http.Controller):
                 channel=channel,
                 description=description,
             )
-            ._test_job(failure_rate=failure_rate)
+            ._test_job(failure_rate=failure_rate, job_duration=job_duration)
         )
         return f"job uuid: {delayed.db_record().uuid}"
 
@@ -259,6 +269,7 @@ class RunJobController(http.Controller):
         channel=None,
         description="Test job",
         failure_rate=0,
+        job_duration=0,
     ):
         model = http.request.env["queue.job"]
         current_count = 0
@@ -281,7 +292,7 @@ class RunJobController(http.Controller):
                         max_retries=max_retries,
                         channel=channel,
                         description="%s #%d" % (description, current_count),
-                    )._test_job(failure_rate=failure_rate)
+                    )._test_job(failure_rate=failure_rate, job_duration=job_duration)
                 )
 
             grouping = random.choice(possible_grouping_methods)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -3,6 +3,7 @@
 
 import logging
 import random
+import time
 from datetime import datetime, timedelta
 
 from odoo import _, api, exceptions, fields, models
@@ -442,7 +443,9 @@ class QueueJob(models.Model):
             )
         return action
 
-    def _test_job(self, failure_rate=0):
+    def _test_job(self, failure_rate=0, job_duration=0):
         _logger.info("Running test job.")
         if random.random() <= failure_rate:
             raise JobError("Job failed")
+        if job_duration:
+            time.sleep(job_duration)


### PR DESCRIPTION
This allows creating test jobs with a long duration for overloading workers and stress testing.