### PR TITLE
[18.0][FIX] queue_job: set exec_time readonly

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -102,6 +102,7 @@ class QueueJob(models.Model):
     date_done = fields.Datetime(readonly=True)
     exec_time = fields.Float(
         string="Execution Time (avg)",
+        readonly=True,
         aggregator="avg",
         help="Time required to execute this job in seconds. Average when grouped.",
     )


### PR DESCRIPTION
A little cosmetics thing.