### PR TITLE
[18.0][IMP] queue_job: take weaker locks

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -41,7 +41,7 @@ class RunJobController(http.Controller):
         """
         env.cr.execute(
             "SELECT uuid FROM queue_job WHERE uuid=%s AND state=%s "
-            "FOR UPDATE SKIP LOCKED",
+            "FOR NO KEY UPDATE SKIP LOCKED",
             (job_uuid, ENQUEUED),
         )
         if not env.cr.fetchone():

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -263,7 +263,7 @@ class Job:
                         uuid = %s
                         AND state = %s
                 )
-            FOR UPDATE SKIP LOCKED;
+            FOR NO KEY UPDATE SKIP LOCKED;
         """,
             [self.uuid, STARTED],
         )

--- a/queue_job/jobrunner/runner.py
+++ b/queue_job/jobrunner/runner.py
@@ -367,7 +367,7 @@ class Database:
                             queue_job_lock
                         WHERE
                             queue_job_lock.queue_job_id = queue_job.id
-                        FOR UPDATE SKIP LOCKED
+                        FOR NO KEY UPDATE SKIP LOCKED
                     )
                     OR NOT EXISTS (
                         SELECT

--- a/test_queue_job/tests/test_requeue_dead_job.py
+++ b/test_queue_job/tests/test_requeue_dead_job.py
@@ -35,7 +35,7 @@ class TestRequeueDeadJob(JobCommonCase):
                     WHERE
                         uuid = %s
                 )
-            FOR UPDATE SKIP LOCKED
+            FOR NO KEY UPDATE SKIP LOCKED
             """,
             [uuid],
         )


### PR DESCRIPTION
Since we are not going to delete records nor modify foreign keys, we can take a weaker lock.

See for instance [this article](https://www.cybertec-postgresql.com/en/select-for-update-considered-harmful-postgresql/) which explains why FOR UPDATE is usually a lock that is too strong.