### PR TITLE
[18.0][FIX] test_queue_job: also add an _unregister_hook function that reverts patches

### DIFF
--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -139,6 +139,13 @@ class ModelTestQueueJob(models.Model):
         )
         return super()._register_hook()
 
+    def _unregister_hook(self):
+        """Remove the patches installed by _register_hook()"""
+        self._revert_method("delay_me")
+        self._revert_method("delay_me_options")
+        self._revert_method("delay_me_context_key")
+        return super()._unregister_hook()
+
     def _job_store_values(self, job):
         value = "JUST_TESTING"
         if job.state == "failed":


### PR DESCRIPTION
Otherwise monkey-patches could be added twice when instantiating new test classes.