### PR TITLE
[16.0][FIX] base_import_async: use chunk size defined by user in front when creating import batches

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -19,9 +19,9 @@ OPT_HAS_HEADER = "has_headers"
 OPT_SEPARATOR = "separator"
 OPT_QUOTING = "quoting"
 OPT_ENCODING = "encoding"
+OPT_CHUNK_SIZE = "limit"
 # options defined in base_import_async/import.js
 OPT_USE_QUEUE = "use_queue"
-OPT_CHUNK_SIZE = "chunk_size"
 # option not available in UI, but usable from scripts
 OPT_PRIORITY = "priority"
 


### PR DESCRIPTION
# Goal

Define the chunk size when importing in background

# Context

When realizing big import, we have the option to define batch sizes for import (feature from odoo's base_import):
<img width="243" height="467" alt="image" src="https://github.com/user-attachments/assets/60dc890e-9105-40f6-9290-6278b3582095" />

But, I realized that base_import_async wasn't using this field and so, it does only batches of 100 records (default value).
This field is set as `options["limit"]` by odoo's front (in .js). Therefore, I have updated the `OPT_CHUNK_SIZE` because "chunk_size" is never defined.