### PR TITLE
[19.0][IMP] queue_job: prevent commit during queue job execution

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -6,6 +6,7 @@ import logging
 import random
 import time
 import traceback
+from contextlib import contextmanager
 from io import StringIO
 
 from psycopg2 import OperationalError, errorcodes
@@ -24,6 +25,29 @@ _logger = logging.getLogger(__name__)
 PG_RETRY = 5  # seconds
 
 DEPENDS_MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
+
+
+@contextmanager
+def _prevent_commit(cr):
+    """Context manager to prevent commits on a cursor.
+
+    Commiting while the job is not finished would release the job lock, causing
+    it to be started again by the dead jobs requeuer.
+    """
+
+    def forbidden_commit(*args, **kwargs):
+        raise RuntimeError(
+            "Commit is forbidden in queue jobs. "
+            "If the current job is a cron running as queue job, "
+            "modify it to run as a normal cron."
+        )
+
+    original_commit = cr.commit
+    cr.commit = forbidden_commit
+    try:
+        yield
+    finally:
+        cr.commit = original_commit
 
 
 class RunJobController(http.Controller):
@@ -69,13 +93,16 @@ class RunJobController(http.Controller):
     def _try_perform_job(cls, env, job):
         """Try to perform the job, mark it done and commit if successful."""
         _logger.debug("%s started", job)
-        job.perform()
-        # Triggers any stored computed fields before calling 'set_done'
-        # so that will be part of the 'exec_time'
-        env.flush_all()
-        job.set_done()
-        job.store()
-        env.flush_all()
+        # TODO refactor, the relation between env and job.env is not clear
+        assert env.cr is job.env.cr
+        with _prevent_commit(env.cr):
+            job.perform()
+            # Triggers any stored computed fields before calling 'set_done'
+            # so that will be part of the 'exec_time'
+            env.flush_all()
+            job.set_done()
+            job.store()
+            env.flush_all()
         env.cr.commit()
         _logger.debug("%s done", job)
 
@@ -201,6 +228,7 @@ class RunJobController(http.Controller):
         size=1,
         failure_rate=0,
         job_duration=0,
+        commit_within_job=False,
     ):
         if not http.request.env.user.has_group("base.group_erp_manager"):
             raise Forbidden(http.request.env._("Access Denied"))
@@ -246,6 +274,7 @@ class RunJobController(http.Controller):
                 description=description,
                 failure_rate=failure_rate,
                 job_duration=job_duration,
+                commit_within_job=commit_within_job,
             )
 
         if size > 1:
@@ -257,6 +286,7 @@ class RunJobController(http.Controller):
                 description=description,
                 failure_rate=failure_rate,
                 job_duration=job_duration,
+                commit_within_job=commit_within_job,
             )
         return ""
 
@@ -269,6 +299,7 @@ class RunJobController(http.Controller):
         size=1,
         failure_rate=0,
         job_duration=0,
+        commit_within_job=False,
     ):
         delayed = (
             http.request.env["queue.job"]
@@ -278,7 +309,11 @@ class RunJobController(http.Controller):
                 channel=channel,
                 description=description,
             )
-            ._test_job(failure_rate=failure_rate, job_duration=job_duration)
+            ._test_job(
+                failure_rate=failure_rate,
+                job_duration=job_duration,
+                commit_within_job=commit_within_job,
+            )
         )
         return f"job uuid: {delayed.db_record().uuid}"
 
@@ -293,6 +328,7 @@ class RunJobController(http.Controller):
         description="Test job",
         failure_rate=0,
         job_duration=0,
+        commit_within_job=False,
     ):
         model = http.request.env["queue.job"]
         current_count = 0
@@ -315,7 +351,11 @@ class RunJobController(http.Controller):
                         max_retries=max_retries,
                         channel=channel,
                         description=f"{description} #{current_count}",
-                    )._test_job(failure_rate=failure_rate, job_duration=job_duration)
+                    )._test_job(
+                        failure_rate=failure_rate,
+                        job_duration=job_duration,
+                        commit_within_job=commit_within_job,
+                    )
                 )
 
             grouping = random.choice(possible_grouping_methods)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -458,9 +458,11 @@ class QueueJob(models.Model):
             )
         return action
 
-    def _test_job(self, failure_rate=0, job_duration=0):
+    def _test_job(self, failure_rate=0, job_duration=0, commit_within_job=False):
         _logger.info("Running test job.")
         if random.random() <= failure_rate:
             raise JobError("Job failed")
         if job_duration:
             time.sleep(job_duration)
+        if commit_within_job:
+            self.env.cr.commit()  # pylint: disable=invalid-commit


### PR DESCRIPTION
Commiting in a job would release the job lock, causing spurious restarts by the dead jobs requeuer.

~Very much draft and untested at this point.~

See also discussion in #889