### PR TITLE
[18.0][FIX] Don't try to enqueue dependent jobs when job failed

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -17,7 +17,7 @@ from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 from ..delay import chain, group
 from ..exception import FailedJobError, RetryableJobError
-from ..job import ENQUEUED, Job
+from ..job import DONE, ENQUEUED, Job
 
 _logger = logging.getLogger(__name__)
 
@@ -155,9 +155,12 @@ class RunJobController(http.Controller):
                 buff.close()
             raise
 
-        _logger.debug("%s enqueue depends started", job)
-        cls._enqueue_dependent_jobs(env, job)
-        _logger.debug("%s enqueue depends done", job)
+        if job.state == DONE:
+            # if not, then job.env.cr could be closed
+            # besides, we would not want to trigger dependent jobs anyway
+            _logger.debug("%s enqueue depends started", job)
+            cls._enqueue_dependent_jobs(env, job)
+            _logger.debug("%s enqueue depends done", job)
 
     @classmethod
     def _get_failure_values(cls, job, traceback_txt, orig_exception):


### PR DESCRIPTION
Running (on 16.0) into:

```
2026-01-23 13:45:15,992 351151 ERROR custdatabase odoo.sql_db: bad query: UPDATE "stock_quant" SET "reserved_quantity" = '45212.0000', "write_date" = '2026-01-23 13:45:15.153636', "write_uid" = 1 WHERE id IN (1793638)
ERROR: could not serialize access due to concurrent update
 
2026-01-23 13:45:15,994 351151 DEBUG custdatabase odoo.addons.queue_job.controllers.main: <Job 7f20f326-3383-4c42-9cdf-7126dbd89743, priority:2> OperationalError, postponed 
2026-01-23 13:45:16,000 351151 DEBUG custdatabase odoo.addons.queue_job.controllers.main: <Job 7f20f326-3383-4c42-9cdf-7126dbd89743, priority:2> postponed 
2026-01-23 13:45:16,001 351151 DEBUG custdatabase odoo.addons.queue_job.controllers.main: <Job 7f20f326-3383-4c42-9cdf-7126dbd89743, priority:2> enqueue depends started 

  File "/data/home/odoo/odoo/auto/addons/muk_rest/models/ir_http.py", line 160, in _dispatch
    response = super()._dispatch(endpoint)
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/http.py", line 761, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/data/home/odoo/odoo/auto/addons/queue_job/controllers/main.py", line 200, in runjob
    self._runjob(env, job)
  File "/data/home/odoo/odoo/auto/addons/queue_job/controllers/main.py", line 169, in _runjob
    cls._enqueue_dependent_jobs(env, job)
  File "/data/home/odoo/odoo/auto/addons/queue_job/controllers/main.py", line 86, in _enqueue_dependent_jobs
    with job.env.cr.savepoint():
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/sql_db.py", line 157, in savepoint
    return _FlushingSavepoint(self)
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/sql_db.py", line 101, in __init__
    super().__init__(cr)
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/sql_db.py", line 76, in __init__
    cr.execute(SQL('SAVEPOINT {}').format(self._name))
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/sql_db.py", line 327, in execute
    _logger.error("bad query: %s\nERROR: %s", tools.ustr(self._obj.query or query), e)
  File "/data/home/odoo/odoo/.venv/lib/python3.10/site-packages/odoo/sql_db.py", line 485, in __getattr__
    raise psycopg2.InterfaceError("Cursor already closed")
psycopg2.InterfaceError: Cursor already closed
```

This is because `job.env.cr` is closed at that point, but it's still being used [here](https://github.com/OCA/queue/blob/18.0/queue_job/controllers/main.py#L87) which may fail. Not the end of the world if it fails, but clutter for the logfile.

Not sure if this is the best solution. I thought about opening a new fresh job cursor, but then again, why would dependent jobs need to be enqueued if the original job failed?