### PR TITLE
[18.0][FIX] queue_job_batch: prevent batches stuck in progress

### DIFF
--- a/queue_job_batch/models/queue_job.py
+++ b/queue_job_batch/models/queue_job.py
@@ -3,8 +3,6 @@
 
 from odoo import api, fields, models
 
-from odoo.addons.queue_job.job import identity_exact
-
 
 class QueueJob(models.Model):
     _inherit = "queue.job"
@@ -20,13 +18,19 @@ class QueueJob(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
-        if vals.get("state", "") == "done":
+        new_state = vals.get("state", "")
+        # Trigger check_state for any terminal state (done, cancelled, failed)
+        if new_state in ("done", "cancelled", "failed"):
             batches = self.env["queue.job.batch"]
             for record in self:
-                if record.state != "done" and record.job_batch_id:
+                # Only trigger if the job wasn't already in a terminal state
+                if (
+                    record.state not in ("done", "cancelled", "failed")
+                    and record.job_batch_id
+                ):
                     batches |= record.job_batch_id
             for batch in batches:
-                # We need to make it with delay in order to prevent two jobs
-                # to work with the same batch
-                batch.with_delay(identity_key=identity_exact).check_state()
+                # Run check_state without identity_key to prevent race condition
+                # where deduplication causes the last job's check_state to be skipped
+                batch.with_delay().check_state()
         return super().write(vals)

--- a/test_queue_job_batch/tests/__init__.py
+++ b/test_queue_job_batch/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_queue_job_batch
+from . import test_fix_batch_stuck

--- a/test_queue_job_batch/tests/test_fix_batch_stuck.py
+++ b/test_queue_job_batch/tests/test_fix_batch_stuck.py
@@ -1,0 +1,97 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestQueueJobBatchFix(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.QueueJob = self.env["queue.job"]
+        self.Batch = self.env["queue.job.batch"]
+        self.TestModel = self.env["test.queue.job"]
+
+    def test_batch_failed_job_triggers_check(self):
+        """Test that a failed job triggers check_state on the batch."""
+        self.cr.execute("delete from queue_job")
+        batch = self.Batch.get_new_batch("TEST_FAIL")
+
+        # Create a job in the batch
+        job = self.TestModel.with_context(job_batch=batch).with_delay().testing_method()
+        job_record = job.db_record()
+
+        # Verify initial state
+        self.assertEqual(batch.state, "pending")
+        self.assertEqual(job_record.state, "pending")
+
+        # Set job to failed
+        # Depending on how queue_job works, writing state might trigger the logic
+        job_record.write({"state": "failed", "exc_info": "Fail"})
+
+        # Find jobs for queue.job.batch
+        check_jobs = self.QueueJob.search(
+            [
+                ("model_name", "=", "queue.job.batch"),
+                ("method_name", "=", "check_state"),
+            ]
+        )
+
+        # Filter for our batch
+        check_jobs = check_jobs.filtered(lambda j: batch in j.records)
+
+        # WITHOUT FIX: This should be empty because "failed" state doesn't trigger
+        self.assertTrue(
+            check_jobs, "check_state job should be created when a job fails"
+        )
+
+    def test_batch_cancelled_job_triggers_check(self):
+        """Test that a cancelled job triggers check_state on the batch."""
+        self.cr.execute("delete from queue_job")
+        batch = self.Batch.get_new_batch("TEST_CANCEL")
+        job = self.TestModel.with_context(job_batch=batch).with_delay().testing_method()
+        job_record = job.db_record()
+
+        job_record.write({"state": "cancelled"})
+
+        check_jobs = self.QueueJob.search(
+            [
+                ("model_name", "=", "queue.job.batch"),
+                ("method_name", "=", "check_state"),
+            ]
+        )
+        check_jobs = check_jobs.filtered(lambda j: batch in j.records)
+
+        self.assertTrue(
+            check_jobs, "check_state job should be created when a job is cancelled"
+        )
+
+    def test_no_deduplication_race_condition(self):
+        """Test that multiple jobs trigger multiple check_state calls."""
+        self.cr.execute("delete from queue_job")
+        batch = self.Batch.get_new_batch("TEST_RACE")
+
+        # Create 2 jobs
+        job1 = (
+            self.TestModel.with_context(job_batch=batch).with_delay().testing_method()
+        )
+        job2 = (
+            self.TestModel.with_context(job_batch=batch).with_delay().testing_method()
+        )
+
+        # Set job1 to done -> creates CheckJob1
+        job1.db_record().write({"state": "done"})
+
+        # Set job2 to done -> creates CheckJob2
+        # If identity_exact is used, CheckJob2 might be deduplicated
+        job2.db_record().write({"state": "done"})
+
+        check_jobs = self.QueueJob.search(
+            [
+                ("model_name", "=", "queue.job.batch"),
+                ("method_name", "=", "check_state"),
+            ]
+        )
+        check_jobs = check_jobs.filtered(lambda j: batch in j.records)
+
+        # WITH FIX: Should have 2 check jobs (no deduplication)
+        # WITHOUT FIX: Should have 1 check job because of deduplication
+        self.assertEqual(
+            len(check_jobs), 2, "Should have 2 check_state jobs (no deduplication)"
+        )


### PR DESCRIPTION
## Summary
This PR fixes a bug where job batches could remain in the "In Progress" state indefinitely, even after all associated jobs had finished.

## Problem
Two main issues were identified in the `check_state` trigger logic:
1. **Race Condition via Deduplication**: Using `identity_exact` with `with_delay()` caused the `check_state` job for the last finishing batch job to be deduplicated (skipped) if a previous `check_state` job from the same batch was still pending or enqueued. This meant the final state transition to "Finished" might never happen.
2. **Missing Terminal States**: The trigger was only looking for the `done` state, ignoring jobs that ended in `failed` or `cancelled`.

## Solution
- Removed `identity_key=identity_exact` from the `check_state` delay call to ensure every job completion attempts a state check, preventing the race condition.
- Updated the trigger condition to include all terminal states: `done`, `cancelled`, and `failed`.

Fixes #810