### PR TITLE
[18.0][IMP] Disable queue with conf file

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -135,6 +135,7 @@ Configuration
       ``--http-interface`` or ``localhost`` if unset
     - ``ODOO_QUEUE_JOB_HTTP_AUTH_USER=jobrunner``, default empty
     - ``ODOO_QUEUE_JOB_HTTP_AUTH_PASSWORD=s3cr3t``, default empty
+    - ``QUEUE_JOB__NO_DELAY=1``, disables the queue for testing purposes
     - Start Odoo with ``--load=web,queue_job`` and ``--workers`` greater
       than 1. [1]_
 
@@ -155,6 +156,7 @@ Configuration
    port = 443
    http_auth_user = jobrunner
    http_auth_password = s3cr3t
+   queue_job__no_delay=True # disables the queue
 
 - Confirm the runner is starting correctly by checking the odoo log
   file:
@@ -481,7 +483,8 @@ running Odoo**
 When you are developing (ie: connector modules) you might want to bypass
 the queue job and run your code immediately.
 
-To do so you can set QUEUE_JOB\__NO_DELAY=1 in your environment.
+To do so you can set QUEUE_JOB\__NO_DELAY=1 in your environment, or
+include queue_job\__no_delay=True in your Odoo server configuration.
 
 **Bypass jobs in tests**
 
@@ -599,7 +602,8 @@ calling ``jobs_tester.perform_enqueued_jobs()`` in your test.
 When you are developing (ie: connector modules) you might want to bypass
 the queue job and run your code immediately.
 
-To do so you can set ``QUEUE_JOB__NO_DELAY=1`` in your environment.
+To do so you can set ``QUEUE_JOB__NO_DELAY=1`` in your environment, or
+include queue_job\__no_delay=True in your Odoo server configuration.
 
 Warning
 

--- a/queue_job/readme/CONFIGURE.md
+++ b/queue_job/readme/CONFIGURE.md
@@ -8,6 +8,7 @@
       or `localhost` if unset
     - `ODOO_QUEUE_JOB_HTTP_AUTH_USER=jobrunner`, default empty
     - `ODOO_QUEUE_JOB_HTTP_AUTH_PASSWORD=s3cr3t`, default empty
+    - `QUEUE_JOB__NO_DELAY=1`, disables the queue for testing purposes
     - Start Odoo with `--load=web,queue_job` and `--workers` greater than
       1.[^1]
 - Using the Odoo configuration file:
@@ -26,6 +27,7 @@ host = load-balancer
 port = 443
 http_auth_user = jobrunner
 http_auth_password = s3cr3t
+queue_job__no_delay=True # disables the queue
 ```
 
 - Confirm the runner is starting correctly by checking the odoo log

--- a/queue_job/readme/USAGE.md
+++ b/queue_job/readme/USAGE.md
@@ -290,7 +290,8 @@ running Odoo**
 When you are developing (ie: connector modules) you might want to bypass
 the queue job and run your code immediately.
 
-To do so you can set QUEUE_JOB\_\_NO_DELAY=1 in your environment.
+To do so you can set QUEUE_JOB\_\_NO_DELAY=1 in your environment,
+or include queue_job__no_delay=True in your Odoo server configuration.
 
 **Bypass jobs in tests**
 
@@ -407,7 +408,8 @@ def test_method_to_test(self):
 When you are developing (ie: connector modules) you might want to bypass
 the queue job and run your code immediately.
 
-To do so you can set `QUEUE_JOB__NO_DELAY=1` in your environment.
+To do so you can set `QUEUE_JOB__NO_DELAY=1` in your environment,
+or include queue_job__no_delay=True in your Odoo server configuration.
 
 Warning
 

--- a/queue_job/utils.py
+++ b/queue_job/utils.py
@@ -4,6 +4,8 @@
 import logging
 import os
 
+from .jobrunner import queue_job_config
+
 _logger = logging.getLogger(__name__)
 
 
@@ -18,4 +20,8 @@ def must_run_without_delay(env):
 
     if env.context.get("queue_job__no_delay"):
         _logger.info("`queue_job__no_delay` ctx key found. NO JOB scheduled.")
+        return True
+
+    if queue_job_config.get("queue_job__no_delay"):
+        _logger.info("`queue_job__no_delay` server config found. NO JOB scheduled.")
         return True


### PR DESCRIPTION
Adds a config param to disable the queue for testing purposes. In the [queue_job] section of your odoo conf file, include queue_job__no_delay=True to disable the job queue. This is particularly useful for odoo.sh and other environments where setting an env var is not convenient. Follows the same format as the env var QUEUE_JOB__NO_DELAY or the context key queue_job__no_delay .