### PR TITLE
[18.0] Skip check of dependencies when a done job has no dependents

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -108,6 +108,10 @@ class RunJobController(http.Controller):
 
     @classmethod
     def _enqueue_dependent_jobs(cls, env, job):
+        if not job.should_check_dependents():
+            return
+
+        _logger.debug("%s enqueue depends started", job)
         tries = 0
         while True:
             try:
@@ -136,6 +140,7 @@ class RunJobController(http.Controller):
                 time.sleep(wait_time)
             else:
                 break
+        _logger.debug("%s enqueue depends done", job)
 
     @classmethod
     def _runjob(cls, env: api.Environment, job: Job) -> None:
@@ -182,9 +187,7 @@ class RunJobController(http.Controller):
                 buff.close()
             raise
 
-        _logger.debug("%s enqueue depends started", job)
         cls._enqueue_dependent_jobs(env, job)
-        _logger.debug("%s enqueue depends done", job)
 
     @classmethod
     def _get_failure_values(cls, job, traceback_txt, orig_exception):

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -172,6 +172,7 @@ class RunJobController(http.Controller):
             # traceback in the logs we should have the traceback when all
             # retries are exhausted
             env.cr.rollback()
+            return
 
         except (FailedJobError, Exception) as orig_exception:
             buff = StringIO()

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -537,6 +537,9 @@ class Job:
             AND state = %s;
         """
 
+    def should_check_dependents(self):
+        return any(self.__reverse_depends_on_uuids)
+
     def enqueue_waiting(self):
         sql = self._get_common_dependent_jobs_query()
         self.env.cr.execute(sql, (PENDING, self.uuid, DONE, WAIT_DEPENDENCIES))

--- a/test_queue_job/tests/test_dependencies.py
+++ b/test_queue_job/tests/test_dependencies.py
@@ -287,3 +287,16 @@ class TestJobDependencies(common.TransactionCase):
         self.assertTrue(jobs[0].graph_uuid)
         self.assertTrue(jobs[1].graph_uuid)
         self.assertEqual(jobs[0].graph_uuid, jobs[1].graph_uuid)
+
+    def test_should_check_dependents(self):
+        job_root = Job(self.method)
+        job_a = Job(self.method)
+        job_a.add_depends({job_root})
+
+        DelayableGraph._ensure_same_graph_uuid([job_root, job_a])
+
+        job_root.store()
+        job_a.store()
+
+        self.assertTrue(job_root.should_check_dependents())
+        self.assertFalse(job_a.should_check_dependents())


### PR DESCRIPTION
Every time a job is done, even if it is not part of a graph, it runs a query to look for dependents to enqueue. Storing the dependent uuids in the "dependencies" field was on purpose to know that we have no further jobs in the graph and that we can skip the check entirely and have no overhead in this case.

It looks like an oversight, we can add the missing condition.