### PR TITLE
[FIX] mock.patch(auto_spec=True) does not exist

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -96,7 +96,6 @@ def trap_jobs():
     with mock.patch(
         "odoo.addons.queue_job.delay.Job",
         name="Job Class",
-        auto_spec=True,
         unsafe=True,
     ) as job_cls_mock:
         with JobsTrap(job_cls_mock) as trap:


### PR DESCRIPTION
There is no parameter auto_spec to mock.patch. This is likely a typo.

Running the tests with Python 3.12 give a RuntimeError
```
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1311, in __init__
    _check_spec_arg_typos(kwargs)
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1287, in _check_spec_arg_typos
    raise RuntimeError(
RuntimeError: 'auto_spec' might be a typo.
```