### PR TITLE
[18.0][FIX] queue_job: Fix TestJson

### DIFF
--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -28,9 +28,13 @@ class TestJson(common.TransactionCase):
             "model": "res.partner",
             "ids": [partner.id],
             "su": False,
-            "context": expected_context,
         }
-        self.assertEqual(json.loads(value_json), expected)
+        result_dict = json.loads(value_json)
+        result_context = result_dict.pop("context")
+        self.assertEqual(result_dict, expected)
+        # context is tested separately as the order/amount of keys is not guaranteed
+        for key in result_context:
+            self.assertEqual(result_context[key], expected_context[key])
 
     def test_encoder_recordset_list(self):
         demo_user = self.env.ref("base.user_demo")
@@ -52,7 +56,20 @@ class TestJson(common.TransactionCase):
                 "context": expected_context,
             },
         ]
-        self.assertEqual(json.loads(value_json), expected)
+        result_dict = json.loads(value_json)
+        for result_value, expected_value in zip(result_dict, expected, strict=False):
+            if isinstance(expected_value, dict):
+                for key in result_value:
+                    if key == "context":
+                        for context_key in result_value["context"]:
+                            self.assertEqual(
+                                result_value["context"][context_key],
+                                expected_value["context"][context_key],
+                            )
+                    else:
+                        self.assertEqual(result_value[key], expected_value[key])
+            else:
+                self.assertEqual(result_value, expected_value)
 
     def test_decoder_recordset(self):
         demo_user = self.env.ref("base.user_demo")


### PR DESCRIPTION
When a module adds a value in context, the tests fail.

For example:
```
  File "/opt/odoo/auto/addons/queue_job/tests/test_json_field.py", line 33, in test_encoder_recordset
    self.assertEqual(json.loads(value_json), expected)
AssertionError: {'_type': 'odoo_recordset', 'model': 'res.p[93 chars]ls'}} != {'uid': 6, '_type': 'odoo_recordset', 'mode[178 chars]ls'}}
  {'_type': 'odoo_recordset',
-  'context': {'lang': 'en_US', 'tz': 'Europe/Brussels'},
+  'context': {'lang': 'en_US',
+              'map_website_id': False,
+              'route_map_website_id': False,
+              'route_start_partner_id': 2,
+              'tz': 'Europe/Brussels'},
   'ids': [1],
   'model': 'res.partner',
   'su': False,
   'uid': 6}
```
```

  File "/opt/odoo/auto/addons/queue_job/tests/test_json_field.py", line 55, in test_encoder_recordset_list
    self.assertEqual(json.loads(value_json), expected)
AssertionError: Lists differ: ['a', 1, {'_type': 'odoo_recordset', 'model': 'res.p[94 chars]s'}}] != ['a', 1, {'uid': 6, '_type': 'odoo_recordset', 'mode[179 chars]s'}}]
First differing element 2:
{'_type': 'odoo_recordset', 'model': 'res.p[93 chars]ls'}}
{'uid': 6, '_type': 'odoo_recordset', 'mode[178 chars]ls'}}
  ['a',
   1,
   {'_type': 'odoo_recordset',
-   'context': {'lang': 'en_US', 'tz': 'Europe/Brussels'},
+   'context': {'lang': 'en_US',
+               'map_website_id': False,
+               'route_map_website_id': False,
+               'route_start_partner_id': 2,
+               'tz': 'Europe/Brussels'},
    'ids': [1],
    'model': 'res.partner',
    'su': False,
    'uid': 6}]
```

In this example, the `partner_external_map` module added `map_website_id`, `route_map_website_id`, and `route_start_partner_id` to the context, which caused the tests of `queue_job` to fail.

This fix ensures that only the keys returned by _job_prepare_context_before_enqueue_keys are preserved in the context, removing any additional values.

@pedrobaeza @christian-ramos-tecnativa could you review this PR?