### PR TITLE
Decode bytes to string in CSV writer

### DIFF
--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -91,9 +91,8 @@ class BaseImportImport(models.TransientModel):
         for row in data:
             cleaned_row = []
             for cell in row:
-                if isinstance(cell, bytes):
-                    # bytes from base64.b64encode() -> decode to base64 string
-                    cell = cell.decode('ascii')
+                if isinstance(cell, (bytes, bytearray)):
+                    cell = cell.decode("utf-8")
                 cleaned_row.append(cell)
             writer.writerow(cleaned_row)
         # create attachment. Remove default values from context

--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -89,7 +89,13 @@ class BaseImportImport(models.TransientModel):
         encoding = options.get(OPT_ENCODING) or "utf-8"
         writer.writerow(fields)
         for row in data:
-            writer.writerow(row)
+            cleaned_row = []
+            for cell in row:
+                if isinstance(cell, bytes):
+                    # bytes from base64.b64encode() -> decode to base64 string
+                    cell = cell.decode('ascii')
+                cleaned_row.append(cell)
+            writer.writerow(cleaned_row)
         # create attachment. Remove default values from context
         context = self.env.context
         context_copy = {}


### PR DESCRIPTION
Clean bytes in rows before writing to CSV to avoid error "This file could not be decoded as an image file."