### PR TITLE
[16.0][FIX] queue_job: rebind args/kwargs to inner cursor in in_temporary_env

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -13,8 +13,26 @@ from datetime import datetime, timedelta
 from random import randint
 
 import odoo
+from odoo.models import BaseModel
 
 from .exception import FailedJobError, NoSuchJobError, RetryableJobError
+
+
+def _rebind_to_env(value, new_env):
+    """Rebind any BaseModel inside `value` to ``new_env``'s cursor.
+
+    Recurses into lists, tuples and dicts. Preserves uid/su/context of each
+    inner env - only the cursor is swapped. Non-recordset values pass through
+    untouched.
+    """
+    if isinstance(value, BaseModel):
+        return value.with_env(value.env(cr=new_env.cr))
+    if isinstance(value, (list, tuple)):
+        return type(value)(_rebind_to_env(v, new_env) for v in value)
+    if isinstance(value, dict):
+        return {k: _rebind_to_env(v, new_env) for k, v in value.items()}
+    return value
+
 
 WAIT_DEPENDENCIES = "wait_dependencies"
 PENDING = "pending"
@@ -533,11 +551,19 @@ class Job:
     def in_temporary_env(self):
         with self.env.registry.cursor() as new_cr:
             env = self.env
-            self._env = env(cr=new_cr)
+            original_args = self.args
+            original_kwargs = self.kwargs
             try:
+                self._env = env(cr=new_cr)
+                self.args = tuple(_rebind_to_env(a, self.env) for a in self.args)
+                self.kwargs = {
+                    k: _rebind_to_env(v, self.env) for k, v in self.kwargs.items()
+                }
                 yield
             finally:
                 self._env = env
+                self.args = original_args
+                self.kwargs = original_kwargs
 
     def _get_common_dependent_jobs_query(self):
         return """

--- a/test_queue_job/data/queue_job_function_data.xml
+++ b/test_queue_job/data/queue_job_function_data.xml
@@ -21,6 +21,14 @@
         <field name="retry_pattern" eval="{3: 180}" />
     </record>
     <record
+        id="job_function_test_queue_job_job_commit_with_arg_records"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="test_queue_job.model_test_queue_job" />
+        <field name="method">job_commit_with_arg_records</field>
+        <field name="allow_commit" eval="True" />
+    </record>
+    <record
         id="job_function_test_queue_channel_job_sub_channel"
         model="queue.job.function"
     >

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -114,6 +114,19 @@ class ModelTestQueueJob(models.Model):
         mutable_kwarg["b"] = 2
         return mutable_arg, mutable_kwarg
 
+    def job_commit_with_arg_records(
+        self, record, record_list=None, record_dict=None, token=None
+    ):
+        assert record.env.cr is self.env.cr, "record argument cursor was not rebound"
+        assert (
+            not record_list or record_list[0].env.cr is self.env.cr
+        ), "record list argument cursor was not rebound"
+        assert (
+            not record_dict or record_dict["record"].env.cr is self.env.cr
+        ), "record dict argument cursor was not rebound"
+        record.env.cr.commit()  # pylint: disable=invalid-commit
+        return token
+
     def delay_me(self, arg, kwarg=None):
         return arg, kwarg
 

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -8,6 +8,7 @@ from unittest import mock
 import odoo.tests.common as common
 
 from odoo.addons.queue_job import identity_exact
+from odoo.addons.queue_job.controllers.main import RunJobController
 from odoo.addons.queue_job.delay import DelayableGraph
 from odoo.addons.queue_job.exception import (
     FailedJobError,
@@ -67,6 +68,17 @@ class TestJobsOnTestingMethod(JobCommonCase):
         test_job = Job(self.method, args=("o", "k"), kwargs={"c": "!"})
         result = test_job.perform()
         self.assertEqual(result, (("o", "k"), {"c": "!"}))
+
+    def test_allow_commit_rebinds_recordsets_in_args(self):
+        record = self.env.user.partner_id
+        job = (
+            self.env["test.queue.job"]
+            .with_delay()
+            .job_commit_with_arg_records(record, [record], {"record": record}, "ok")
+        )
+        RunJobController._runjob(self.env, job)
+        self.assertEqual(job.state, DONE)
+        self.assertEqual(job.result, "ok")
 
     def test_retryable_error(self):
         test_job = Job(self.method, kwargs={"raise_retry": True}, max_retries=3)


### PR DESCRIPTION
Job.in_temporary_env() rebinds self.recordset to the inner cursor via the @env.setter, but leaves self.args and self.kwargs on the outer worker cursor where _prevent_commit is patched. A cr.commit() reached through any recordset argument then raises RuntimeError: Commit is forbidden in queue jobs even with allow_commit=True. Typical case: a connector exporter taking a binding and a related record, committing inside binder.bind_export(...).            
  
Introduced by #910.                                 

Fix: after the env swap, walk self.args and self.kwargs recursively (BaseModel, list, tuple, dict) and rebind each recordset with value.with_env(value.env(cr=new_env.cr)) — only the cursor changes, uid/su/context are kept. Originals restored in the finally, like self._env.
                                                                                                                                                          
Regression test in test_queue_job passes the same recordset as positional arg, list element and dict value, checks cursor identity in all three, then commits. Run through RunJobController._runjob. 