### PR TITLE
[18.0][FIX] queue_job: remove create/delete permissions

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -424,7 +424,7 @@ class QueueJob(models.Model):
                     limit=1000,
                 )
                 if jobs:
-                    jobs.unlink()
+                    jobs.sudo().unlink()
                     if not config["test_enable"]:
                         self.env.cr.commit()  # pylint: disable=E8102
                 else:

--- a/queue_job/security/ir.model.access.csv
+++ b/queue_job/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_queue_job_manager,queue job manager,queue_job.model_queue_job,queue_job.group_queue_job_manager,1,1,1,1
+access_queue_job_manager,queue job manager,queue_job.model_queue_job,queue_job.group_queue_job_manager,1,1,0,0
 access_queue_job_lock_manager,queue job lock manager,queue_job.model_queue_job_lock,queue_job.group_queue_job_manager,1,0,0,0
 access_queue_job_function_manager,queue job functions manager,queue_job.model_queue_job_function,queue_job.group_queue_job_manager,1,1,1,1
 access_queue_job_channel_manager,queue job channel manager,queue_job.model_queue_job_channel,queue_job.group_queue_job_manager,1,1,1,1


### PR DESCRIPTION
Jobs are always created through sudo() in the Job class, and always deleted by the cron, never by users.

See discussion on https://github.com/OCA/queue/pull/802#issuecomment-4341581616