### PR TITLE
[19.0][FIX] queue_job: add openupgradelib to external_dependencies

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "LGPL-3",
     "category": "Generic Modules",
     "depends": ["mail", "base_sparse_field", "web"],
-    "external_dependencies": {"python": ["requests"]},
+    "external_dependencies": {"python": ["requests", "openupgradelib"]},
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # generated from manifests external_dependencies
+openupgradelib
 requests


### PR DESCRIPTION
**Issue:** #809

**Problem:**
The module uses `openupgradelib` in migration scripts (`migrations/18.0.1.0.0/pre-migrate.py`) but it was not declared in `external_dependencies`, causing installation failures when `openupgradelib` is not already installed.

**Fix:**
Add `openupgradelib` to the `external_dependencies` python list in the manifest.

**Before:**
```python
"external_dependencies": {"python": ["requests"]},
```

**After:**
```python
"external_dependencies": {"python": ["requests", "openupgradelib"]},
```

Fixes #809