### PR TITLE
[IMP] queue_job: Handle TypeError when JSON-encoding context.

### DIFF
--- a/queue_job/fields.py
+++ b/queue_job/fields.py
@@ -103,7 +103,10 @@ class JobEncoder(json.JSONEncoder):
             }
         elif isinstance(obj, lazy):
             return obj._value
-        return json.JSONEncoder.default(self, obj)
+        try:
+            return json.JSONEncoder.default(self, obj)
+        except TypeError:
+            return None
 
 
 class JobDecoder(json.JSONDecoder):

--- a/queue_job/tests/test_json_field.py
+++ b/queue_job/tests/test_json_field.py
@@ -154,6 +154,18 @@ class TestJson(common.TransactionCase):
         value = json.loads(value_json, cls=JobDecoder, env=self.env)
         self.assertEqual(value, expected)
 
+    def test_encoder_object(self):
+        value = [object()]
+        value_json = json.dumps(value, cls=JobEncoder)
+        expected = [None]
+        self.assertEqual(json.loads(value_json), expected)
+
+    def test_decoder_object(self):
+        value_json = "[null]"
+        expected = [None]
+        value = json.loads(value_json, cls=JobDecoder, env=self.env)
+        self.assertEqual(value, expected)
+
     def test_encoder_etree(self):
         etree_el = etree.Element("root", attr="val")
         etree_el.append(etree.Element("child", attr="val"))


### PR DESCRIPTION
This nulls out unencodable values when serializing the job context, instead of raising an error.