### PR TITLE
[18.0][FIX] queue_job: fix verbose warning in tests with patched methods

### DIFF
--- a/queue_job/tests/common.py
+++ b/queue_job/tests/common.py
@@ -6,10 +6,18 @@ from itertools import groupby
 from operator import attrgetter
 from unittest import TestCase, mock
 
+from odoo.tests.common import SETATTR_SOURCES
+
 from odoo.addons.queue_job.delay import Graph
 
 # pylint: disable=odoo-addons-relative-import
 from odoo.addons.queue_job.job import Job
+
+# Register queue_job patcher as a known path to prevent verbose warning
+# in tests when methods are patched.
+SETATTR_SOURCES["_patch_method"] = tuple(
+    list(SETATTR_SOURCES.get("_patch_method", [])) + ["/queue_job/models/base.py"],
+)
 
 
 @contextmanager
@@ -206,7 +214,7 @@ class JobsTrap:
 
         if expected_call not in actual_calls:
             raise AssertionError(
-                "Job {} was not enqueued.\n" "Actual enqueued jobs:\n{}".format(
+                "Job {} was not enqueued.\nActual enqueued jobs:\n{}".format(
                     self._format_job_call(expected_call),
                     "\n".join(
                         f" * {self._format_job_call(call)}" for call in actual_calls


### PR DESCRIPTION
Methods patched with _patch_method leads to a lot of warnings during tests that look like:

```
2026-05-22 08:44:57,099 1 INFO testdb odoo.tests.common: /odoo/external-src/queue/queue_job/models/base.py:270:_patch_method setting edi.exchange.record.action_exchange_generate to <function EDIExchangeRecord.action_exchange_generate at 0x7f23b62a0680>
Stack (most recent call last):
  File "/usr/local/bin/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/odoo/src/odoo/cli/server.py", line 182, in run
    main(args)
  File "/odoo/src/odoo/cli/server.py", line 175, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/service/server.py", line 1457, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/service/server.py", line 622, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/service/server.py", line 1388, in preload_registries
    result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
  File "/odoo/src/odoo/tests/loader.py", line 118, in run_suite
    suite(results)
  File "/usr/local/lib/python3.12/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/odoo/src/odoo/tests/suite.py", line 49, in run
    self._tearDownPreviousClass(None, result)
  File "/odoo/src/odoo/tests/suite.py", line 190, in _tearDownPreviousClass
    super()._tearDownPreviousClass(test, result)
  File "/odoo/src/odoo/tests/suite.py", line 112, in _tearDownPreviousClass
    previousClass.doClassCleanups()
  File "/odoo/src/odoo/tests/case.py", line 247, in doClassCleanups
    function(*args, **kwargs)
  File "/odoo/src/odoo/tests/common.py", line 989, in reset_changes
    cls.registry.setup_models(cr)
  File "/usr/local/lib/python3.12/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 375, in setup_models
    model._register_hook()
  File "/odoo/external-src/edi-framework/edi_queue_oca/models/edi_exchange_record.py", line 26, in _register_hook
    self._patch_method(function, self._patch_job_auto_delay(function))
  File "/odoo/external-src/queue/queue_job/models/base.py", line 270, in _patch_method
    setattr(cls, name, wrapped)
  File "/odoo/src/odoo/tests/common.py", line 971, in metamodel_setattr
    _logger.runbot(
  File "/odoo/src/odoo/netsvc.py", line 360, in runbot
    self.log(logging.RUNBOT, message, *args, **kws)
```