### PR TITLE
[MIG] base_import_async: Migration to 19.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 exclude: |
   (?x)
   # NOT INSTALLABLE ADDONS
-  ^base_import_async/|
   ^queue_job_batch/|
   ^queue_job_cron/|
   ^queue_job_cron_jobrunner/|

--- a/base_import_async/__manifest__.py
+++ b/base_import_async/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Asynchronous Import",
     "summary": "Import CSV files in the background",
-    "version": "18.0.1.0.0",
+    "version": "19.0.1.0.0",
     "author": "Akretion, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/queue",
@@ -20,6 +20,6 @@
             "base_import_async/static/src/xml/import_data_sidepanel.xml",
         ],
     },
-    "installable": False,
+    "installable": True,
     "development_status": "Production/Stable",
 }

--- a/base_import_async/models/base_import_import.py
+++ b/base_import_async/models/base_import_import.py
@@ -9,7 +9,7 @@ import csv
 from io import BytesIO, StringIO, TextIOWrapper
 from os.path import splitext
 
-from odoo import _, api, models
+from odoo import models
 from odoo.models import fix_import_export_id_paths
 
 from odoo.addons.base_import.models.base_import import ImportValidationError
@@ -30,6 +30,7 @@ INIT_PRIORITY = 100
 DEFAULT_CHUNK_SIZE = 100
 
 
+# pylint: disable=no-wizard-in-models
 class BaseImportImport(models.TransientModel):
     _inherit = "base_import.import"
 
@@ -55,10 +56,11 @@ class BaseImportImport(models.TransientModel):
             translated_model_name = search_result[0][1]
         else:
             translated_model_name = self._description
-        description = _("Import %(model)s from file %(from_file)s") % {
-            "model": translated_model_name,
-            "from_file": self.file_name,
-        }
+        description = self.env._(
+            "Import %(model)s from file %(from_file)s",
+            model=translated_model_name,
+            from_file=self.file_name,
+        )
         attachment = self._create_csv_attachment(
             import_fields, data, options, self.file_name
         )
@@ -78,7 +80,6 @@ class BaseImportImport(models.TransientModel):
         )
         attachment.write({"res_model": "queue.job", "res_id": queue_job.id})
 
-    @api.returns("ir.attachment")
     def _create_csv_attachment(self, fields, data, options, file_name):
         # write csv
         f = StringIO()
@@ -155,16 +156,15 @@ class BaseImportImport(models.TransientModel):
             model_obj, fields, data, chunk_size
         ):
             chunk = str(priority - INIT_PRIORITY).zfill(padding)
-            description = _(
+            description = self.env._(
                 "Import %(model)s from file %(file_name)s - "
-                "#%(chunk)s - lines %(from)s to %(to)s"
-            ) % {
-                "model": translated_model_name,
-                "file_name": file_name,
-                "chunk": chunk,
-                "from": row_from + 1 + header_offset,
-                "to": row_to + 1 + header_offset,
-            }
+                "#%(chunk)s - lines %(row_from)s to %(row_to)s",
+                model=translated_model_name,
+                file_name=file_name,
+                chunk=chunk,
+                row_from=row_from + 1 + header_offset,
+                row_to=row_to + 1 + header_offset,
+            )
             # create a CSV attachment and enqueue the job
             root, ext = splitext(file_name)
             attachment = self._create_csv_attachment(

--- a/base_import_async/models/queue_job.py
+++ b/base_import_async/models/queue_job.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import models
 
 
 class QueueJob(models.Model):
@@ -11,7 +11,7 @@ class QueueJob(models.Model):
 
     def _related_action_attachment(self):
         return {
-            "name": _("Attachment"),
+            "name": self.env._("Attachment"),
             "type": "ir.actions.act_window",
             "res_model": "ir.attachment",
             "view_mode": "form",

--- a/setup/_metapackage/pyproject.toml
+++ b/setup/_metapackage/pyproject.toml
@@ -2,6 +2,7 @@
 name = "odoo-addons-oca-queue"
 version = "19.0.20260104.0"
 dependencies = [
+    "odoo-addon-base_import_async==19.0.*",
     "odoo-addon-queue_job==19.0.*",
     "odoo-addon-test_queue_job==19.0.*",
 ]


### PR DESCRIPTION
## Description

`base_import_async` is still flagged `installable: False` with `version: 18.0.1.0.0` on the `19.0` branch. This PR bumps it to V19 and makes it installable, with the API changes required by V19 and the pylint fixes triggered by the strict OCA mandatory checks now applying to the module.

## Changes

### Code

- Bumped `__manifest__.py`: `version` `18.0.1.0.0` → `19.0.1.0.0`, `installable` `False` → `True`.
- Removed `@api.returns("ir.attachment")` decorator on `_create_csv_attachment` (decorator no longer supported in V19; the method already returns an `ir.attachment` recordset).
- Replaced `_()` with `self.env._()` everywhere (W8161 `prefer-env-translation`, see [odoo/odoo#174844](https://github.com/odoo/odoo/pull/174844)).
- Switched to the kwarg form of `self.env._()` instead of `_("...") % {...}` formatting (W8301 `translation-not-lazy`). Renamed `%(from)s` / `%(to)s` to `%(row_from)s` / `%(row_to)s` because `from` is a Python reserved word and can't be used as a kwarg name.
- Removed now-unused imports (`_`, `api`).
- Annotated `BaseImportImport` with `# pylint: disable=no-wizard-in-models` — the class extends core `base_import.import` (which itself lives in core Odoo's `base_import/models/`), so following the upstream layout is the right thing here. Open to feedback if reviewers prefer moving the file to `wizard/`.

### Repo-level

- Removed `^base_import_async/|` from `.pre-commit-config.yaml` "NOT INSTALLABLE ADDONS" exclude list.
- Added `odoo-addon-base_import_async==19.0.*` to `setup/_metapackage/pyproject.toml` dependencies.

## Context

Discovered while migrating a large Odoo V12 → V19 deployment (Reanova ERP) where `base_import_async` is a dependency of a vendored module (`customer_file_importation`).

## Tests

Tested on a V19 install with a 35k-row partner CSV: import is correctly queued as a `queue.job` and processed in the background. The `ir.attachment` returned by `_create_csv_attachment` is properly linked to the queue job (`res_model="queue.job"`).

## Note on `queue_job_cron` (dropped from this PR)

This PR originally also bumped `queue_job_cron` to 19.0, but it was dropped because its `test_queue_job_cron.TestQueueJobCron.test_queue_job_cron_callback` fails on V19 with:

```
AssertionError: Cannot commit or rollback a cursor from inside a test,
this will lead to a broken cursor when trying to rollback the test.
Please rollback to a specific savepoint instead or open another cursor
if really necessary
```

V19 strengthened the test framework to forbid `cr.commit()` / `cr.rollback()` from within `TransactionCase`. The `_callback` test triggers an internal `cr.commit()` in `ir.cron._callback`, which the V19 test framework now treats as a hard failure.

That migration needs its own PR with a test refactor (savepoint-based or by mocking the cron callback's commit) and is out of scope here.
