### PR TITLE
[12.0][FIX] queue_job: don't enqueue dependent jobs after a retryable postpone (closed cursor)

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {'name': 'Job Queue',
- 'version': '12.0.4.1.0',
+ 'version': '12.0.4.1.1',
  'author': 'Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)',
  'website': 'https://github.com/OCA/queue',
  'license': 'LGPL-3',

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -148,6 +148,12 @@ class RunJobController(http.Controller):
             # traceback in the logs we should have the traceback when all
             # retries are exhausted
             env.cr.rollback()
+            # A postponed job is not done: it must not release its dependent
+            # jobs. Returning here also avoids calling _enqueue_dependent_jobs
+            # with job.env pointing to the now-closed cursor that
+            # retry_postpone() opened and closed, which would raise
+            # "Unable to use a closed cursor".
+            return ""
 
         except (FailedJobError, Exception) as orig_exception:
             buff = StringIO()


### PR DESCRIPTION
## Problem

Graph jobs that hit a Postgres serialization/concurrency error crash the `/queue_job/runjob` request with:

    psycopg2.OperationalError: Unable to use a closed cursor.

Traceback tail:

    controllers/main.py, in _enqueue_dependent_jobs -> job.enqueue_waiting()
    job.py, in enqueue_waiting -> self.env.cr.execute(...)
    OperationalError: Unable to use a closed cursor.

## Root cause

In `RunJobController.runjob`, the `except RetryableJobError` handler calls the local `retry_postpone()`, which does:

```python
job.env.clear()
with odoo.registry(job.env.cr.dbname).cursor() as new_cr:
    job.env = job.env(cr=new_cr)
    ...
    new_cr.commit()
# new_cr is closed here, but job.env.cr still points at it
```

The handler ended with env.cr.rollback() but no return, so control fell through to self._enqueue_dependent_jobs(env, job) ->
job.enqueue_waiting(), which runs self.env.cr.execute(...) on the closed cursor. This only triggers for jobs in a dependency graph that hit a retryable error, which is why it's intermittent.


## Fix

Return right after the rollback in the RetryableJobError branch. A postponed job isn't done, so it must not release its dependents — and this avoids using the closed cursor. This matches upstream OCA queue_job behaviour in 14.0/15.0/16.0.