### PR TITLE
[IMP] queue_job: Set doctest.REPORT_ONLY_FIRST_FAILURE option.

### DIFF
--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -12,4 +12,6 @@ from odoo.addons.queue_job.jobrunner import channels
 @tagged("doctest")
 class TestDoctest(BaseCase):
     def test_doctest(self):
-        doctest.testmod(channels, exclude_empty=True, raise_on_error=True)
+        doctest.testmod(
+            channels, exclude_empty=True, optionflags=doctest.REPORT_ONLY_FIRST_FAILURE
+        )

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -13,7 +13,9 @@ from odoo.addons.queue_job.jobrunner import runner
 @tagged("doctest")
 class TestDoctest(BaseCase):
     def test_doctest(self):
-        doctest.testmod(runner, exclude_empty=True, raise_on_error=True)
+        doctest.testmod(
+            runner, exclude_empty=True, optionflags=doctest.REPORT_ONLY_FIRST_FAILURE
+        )
 
 
 @tagged("-at_install", "post_install")


### PR DESCRIPTION
This improves doctest output from useless

```
Traceback (most recent call last):
  File "/mnt/extra-addons/oca/queue/queue_job/tests/test_runner_channels.py", line 15, in test_doctest
    doctest.testmod(
  File "/usr/lib/python3.12/doctest.py", line 1998, in testmod
    runner.run(test)
  File "/usr/lib/python3.12/doctest.py", line 1886, in run
    r = DocTestRunner.run(self, test, compileflags, out, False)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/doctest.py", line 1525, in run
    return self.__run(test, compileflags, out)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/doctest.py", line 1426, in __run
    self.report_failure(out, test, example, got)
  File "/usr/lib/python3.12/doctest.py", line 1895, in report_failure
    raise DocTestFailure(test, example, got)
doctest.DocTestFailure: <DocTest odoo.addons.queue_job.jobrunner.channels.ChannelManager.simple_configure from /mnt/extra-addons/oca/queue/queue_job/jobrunner/channels.py:906 (12 examples)>
```

to useful

```
**********************************************************************
File "/mnt/extra-addons/oca/queue/queue_job/jobrunner/channels.py", line 925, in odoo.addons.queue_job.jobrunner.channels.ChannelManager.simple_configure
Failed example:
    cm.get_channel_by_name('seq').capacity
Expected:
    2
Got:
    1
**********************************************************************
1 items had failures:
   1 of  12 in odoo.addons.queue_job.jobrunner.channels.ChannelManager.simple_configure
***Test Failed*** 1 failures.
```