### PR TITLE
[FIX] queue_job: Fail build on doctest failure.

### DIFF
--- a/queue_job/tests/test_runner_channels.py
+++ b/queue_job/tests/test_runner_channels.py
@@ -12,6 +12,7 @@ from odoo.addons.queue_job.jobrunner import channels
 @tagged("doctest")
 class TestDoctest(BaseCase):
     def test_doctest(self):
-        doctest.testmod(
+        results = doctest.testmod(
             channels, exclude_empty=True, optionflags=doctest.REPORT_ONLY_FIRST_FAILURE
         )
+        self.assertEqual(results.failed, 0, "doctest failed")

--- a/queue_job/tests/test_runner_runner.py
+++ b/queue_job/tests/test_runner_runner.py
@@ -13,9 +13,10 @@ from odoo.addons.queue_job.jobrunner import runner
 @tagged("doctest")
 class TestDoctest(BaseCase):
     def test_doctest(self):
-        doctest.testmod(
+        results = doctest.testmod(
             runner, exclude_empty=True, optionflags=doctest.REPORT_ONLY_FIRST_FAILURE
         )
+        self.assertEqual(results.failed, 0, "doctest failed")
 
 
 @tagged("-at_install", "post_install")


### PR DESCRIPTION
This restores the build failures lost by https://github.com/OCA/queue/pull/946.