### PR TITLE
[16.0][IMP] queue_job: defer job execution across rolling deployments and module installs

### DIFF
--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -148,6 +148,17 @@ Configuration
   picked up a rolling deployment's update). Disable with the
   ``queue_job.check_modules_up_to_date`` system parameter set to ``False``.
 
+* By default, a worker will also defer any job while modules are being
+  installed/upgraded/removed anywhere in the cluster (the same condition core
+  Odoo already uses to skip scheduled actions, see ``ir_cron``), since a job
+  committed early in an install (e.g. from a ``post_init_hook``) may reference
+  code that doesn't match the database until the install fully completes.
+  Pending states older than ``queue_job.install_in_progress_timeout_minutes``
+  (default ``60``) are treated as abandoned and ignored, with a warning
+  logged, rather than blocking jobs forever. Disable the check entirely with
+  the ``queue_job.check_install_in_progress`` system parameter set to
+  ``False``.
+
 Usage
 =====
 

--- a/queue_job/README.rst
+++ b/queue_job/README.rst
@@ -143,6 +143,11 @@ Configuration
 
 * Jobs that remain in `enqueued` or `started` state (because, for instance, their worker has been killed) will be automatically re-queued.
 
+* By default, a worker will defer (not execute) a job if its own installed
+  module code no longer matches what the database expects (e.g. it hasn't yet
+  picked up a rolling deployment's update). Disable with the
+  ``queue_job.check_modules_up_to_date`` system parameter set to ``False``.
+
 Usage
 =====
 

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -29,6 +29,7 @@ PG_RETRY = 5  # seconds
 DEPENDS_MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
 
 MODULES_OUTDATED_POSTPONE_SECONDS = 15
+INSTALL_IN_PROGRESS_POSTPONE_SECONDS = 15
 
 # How long a "is this worker's module code up to date" verdict is cached before
 # being recomputed, per database (a single process can serve several). Keeps a
@@ -118,6 +119,75 @@ class RunJobController(http.Controller):
         if not config["test_enable"]:
             env.cr.commit()
         _logger.debug("%s done", job)
+
+    @classmethod
+    def _install_in_progress(cls, env):
+        """True while any module is marked to be installed/upgraded/removed.
+
+        Same guard core already applies to cron jobs
+        (ir_cron._check_modules_state): while an install/upgrade is running
+        anywhere in the cluster, module states sit at 'to install'/'to
+        upgrade'/'to remove' in the database, and only flip back once the
+        operation completes (or core's reset_modules_state() clears them on
+        failure). Jobs executed during that window may run with code that
+        does not yet match what the database will end up recording -- a
+        module's own 'installed' state and latest_version are only committed
+        near the end of its install, but data/hooks that ran earlier in the
+        same install (e.g. a post_init_hook enqueuing a job) may already be
+        committed and dispatchable. _worker_is_outdated() has nothing to
+        compare against in that window (the module isn't even marked
+        installed yet); this check covers exactly that gap.
+
+        Deliberately not cached like _worker_is_outdated(): the whole point
+        is that a job committed by a post_init_hook becomes visible in the
+        same commit as the pending module state, so a fresh read makes this
+        check exact. A TTL would reopen the race for its duration. The query
+        is one cheap aggregate over ir_module_module.
+
+        Pending states older than
+        queue_job.install_in_progress_timeout_minutes (default 60) are
+        treated as abandoned (e.g. modules left marked by a crashed/killed
+        process) and ignored, with a warning logged, rather than freezing
+        job processing forever. Disable the whole check with the
+        queue_job.check_install_in_progress system parameter.
+        """
+        icp = env["ir.config_parameter"].sudo()
+        if icp.get_param("queue_job.check_install_in_progress", "True") == "False":
+            return False
+
+        timeout_minutes = int(
+            icp.get_param("queue_job.install_in_progress_timeout_minutes", "60")
+        )
+        env.cr.execute(
+            """
+            SELECT COUNT(*),
+                   MAX(COALESCE(write_date, create_date))
+                       >= (now() AT TIME ZONE 'UTC') - %s * interval '1 minute'
+            FROM ir_module_module
+            WHERE state IN ('to install', 'to upgrade', 'to remove')
+            """,
+            (timeout_minutes,),
+        )
+        pending, fresh = env.cr.fetchone()
+        if not pending:
+            return False
+        if not fresh:
+            _logger.warning(
+                "%d module(s) have been marked to install/upgrade/remove for "
+                "more than %d minutes; assuming an abandoned operation and "
+                "resuming job processing",
+                pending,
+                timeout_minutes,
+            )
+            return False
+        # Only reached while an install is ACTIVELY in progress (pending &
+        # fresh) -- the common no-install case already returned False above.
+        # Bust the version-check cache so the first job dispatched after the
+        # install completes recomputes _worker_is_outdated() freshly instead
+        # of reusing a pre-install verdict for up to
+        # MODULES_UP_TO_DATE_CACHE_SECONDS.
+        _modules_up_to_date_cache.pop(env.cr.dbname, None)
+        return True
 
     @classmethod
     def _worker_is_outdated(cls, env):
@@ -216,6 +286,22 @@ class RunJobController(http.Controller):
                 job.postpone(result=message, seconds=seconds)
                 job.set_pending(reset_retry=False)
                 job.store()
+
+        if cls._install_in_progress(env):
+            _logger.info(
+                "%s: modules are being installed/upgraded somewhere in the "
+                "cluster; postponing %ss",
+                job,
+                INSTALL_IN_PROGRESS_POSTPONE_SECONDS,
+            )
+            retry_postpone(
+                job,
+                "modules install in progress",
+                seconds=INSTALL_IN_PROGRESS_POSTPONE_SECONDS,
+            )
+            if not config["test_enable"]:
+                env.cr.rollback()
+            return
 
         if cls._worker_is_outdated(env):
             _logger.info(

--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -14,6 +14,7 @@ from psycopg2 import OperationalError, errorcodes
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from odoo import SUPERUSER_ID, _, api, http, tools
+from odoo.modules.module import get_manifest
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 from odoo.tools import config
 
@@ -26,6 +27,14 @@ _logger = logging.getLogger(__name__)
 PG_RETRY = 5  # seconds
 
 DEPENDS_MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
+
+MODULES_OUTDATED_POSTPONE_SECONDS = 15
+
+# How long a "is this worker's module code up to date" verdict is cached before
+# being recomputed, per database (a single process can serve several). Keeps a
+# busy jobrunner from re-querying ir.module.module on every single job dispatch.
+MODULES_UP_TO_DATE_CACHE_SECONDS = 5
+_modules_up_to_date_cache = {}  # dbname -> (checked_at, outdated: bool)
 
 
 @contextmanager
@@ -111,6 +120,64 @@ class RunJobController(http.Controller):
         _logger.debug("%s done", job)
 
     @classmethod
+    def _worker_is_outdated(cls, env):
+        """True if this worker's own on-disk module code no longer matches
+        what the database considers the currently installed version, for at
+        least one installed module.
+
+        ir.module.module.installed_version is a non-stored compute that reads
+        the manifest fresh from *this process's* addons_path (get_manifest()
+        is lru_cached per process, so this is cheap after the first call).
+        ir.module.module.latest_version is what the module loader persisted to
+        the database the last time this module was actually
+        installed/upgraded (see odoo/modules/loading.py). A mismatch means
+        some other process has since upgraded this module past what this
+        worker is currently running -- most commonly, one worker in a
+        multi-process or multi-host deployment has picked up new code and run
+        an upgrade, while this one is still serving requests with the old
+        code, in the window before it gets restarted (a rolling-deployment
+        race). Running a job in that state risks acting on stale files/logic
+        that no longer match the database.
+
+        The result is cached briefly, per database, so a busy queue doesn't
+        re-run this on every single job (see MODULES_UP_TO_DATE_CACHE_SECONDS).
+
+        Disable via the ``queue_job.check_modules_up_to_date`` system
+        parameter (set to ``"False"``); enabled by default.
+        """
+        icp = env["ir.config_parameter"].sudo()
+        if icp.get_param("queue_job.check_modules_up_to_date", "True") == "False":
+            return False
+
+        dbname = env.cr.dbname
+        now = time.monotonic()
+        cached = _modules_up_to_date_cache.get(dbname)
+        if cached and now - cached[0] < MODULES_UP_TO_DATE_CACHE_SECONDS:
+            return cached[1]
+
+        outdated = False
+        modules = env["ir.module.module"].sudo().search([("state", "=", "installed")])
+        for module in modules:
+            manifest = get_manifest(module.name)
+            if not manifest:
+                # Can't read this module's manifest from this process's
+                # addons_path (e.g. a module removed from disk but still
+                # marked installed in the database) -- skip it rather than
+                # treat an unreadable manifest as evidence of staleness.
+                continue
+            on_disk_version = manifest.get("version")
+            if (
+                on_disk_version
+                and module.latest_version
+                and on_disk_version != module.latest_version
+            ):
+                outdated = True
+                break
+
+        _modules_up_to_date_cache[dbname] = (now, outdated)
+        return outdated
+
+    @classmethod
     def _enqueue_dependent_jobs(cls, env, job):
         tries = 0
         while True:
@@ -149,6 +216,21 @@ class RunJobController(http.Controller):
                 job.postpone(result=message, seconds=seconds)
                 job.set_pending(reset_retry=False)
                 job.store()
+
+        if cls._worker_is_outdated(env):
+            _logger.info(
+                "%s: this worker's module code is outdated relative to the "
+                "database (likely a rolling deployment in progress); "
+                "postponing %ss",
+                job,
+                MODULES_OUTDATED_POSTPONE_SECONDS,
+            )
+            retry_postpone(
+                job, "worker outdated", seconds=MODULES_OUTDATED_POSTPONE_SECONDS
+            )
+            if not config["test_enable"]:
+                env.cr.rollback()
+            return
 
         try:
             try:

--- a/queue_job/readme/CONFIGURE.rst
+++ b/queue_job/readme/CONFIGURE.rst
@@ -53,3 +53,14 @@
   module code no longer matches what the database expects (e.g. it hasn't yet
   picked up a rolling deployment's update). Disable with the
   ``queue_job.check_modules_up_to_date`` system parameter set to ``False``.
+
+* By default, a worker will also defer any job while modules are being
+  installed/upgraded/removed anywhere in the cluster (the same condition core
+  Odoo already uses to skip scheduled actions, see ``ir_cron``), since a job
+  committed early in an install (e.g. from a ``post_init_hook``) may reference
+  code that doesn't match the database until the install fully completes.
+  Pending states older than ``queue_job.install_in_progress_timeout_minutes``
+  (default ``60``) are treated as abandoned and ignored, with a warning
+  logged, rather than blocking jobs forever. Disable the check entirely with
+  the ``queue_job.check_install_in_progress`` system parameter set to
+  ``False``.

--- a/queue_job/readme/CONFIGURE.rst
+++ b/queue_job/readme/CONFIGURE.rst
@@ -48,3 +48,8 @@
        of running Odoo is obviously not for production purposes.
 
 * Jobs that remain in `enqueued` or `started` state (because, for instance, their worker has been killed) will be automatically re-queued.
+
+* By default, a worker will defer (not execute) a job if its own installed
+  module code no longer matches what the database expects (e.g. it hasn't yet
+  picked up a rolling deployment's update). Disable with the
+  ``queue_job.check_modules_up_to_date`` system parameter set to ``False``.

--- a/queue_job/static/description/index.html
+++ b/queue_job/static/description/index.html
@@ -503,6 +503,10 @@ of running Odoo is obviously not for production purposes.</td></tr>
 </table>
 <ul class="simple">
 <li>Jobs that remain in <cite>enqueued</cite> or <cite>started</cite> state (because, for instance, their worker has been killed) will be automatically re-queued.</li>
+<li>By default, a worker will defer (not execute) a job if its own installed
+module code no longer matches what the database expects (e.g. it hasn’t yet
+picked up a rolling deployment’s update). Disable with the
+<tt class="docutils literal">queue_job.check_modules_up_to_date</tt> system parameter set to <tt class="docutils literal">False</tt>.</li>
 </ul>
 </div>
 <div class="section" id="usage">

--- a/queue_job/static/description/index.html
+++ b/queue_job/static/description/index.html
@@ -507,6 +507,16 @@ of running Odoo is obviously not for production purposes.</td></tr>
 module code no longer matches what the database expects (e.g. it hasn’t yet
 picked up a rolling deployment’s update). Disable with the
 <tt class="docutils literal">queue_job.check_modules_up_to_date</tt> system parameter set to <tt class="docutils literal">False</tt>.</li>
+<li>By default, a worker will also defer any job while modules are being
+installed/upgraded/removed anywhere in the cluster (the same condition core
+Odoo already uses to skip scheduled actions, see <tt class="docutils literal">ir_cron</tt>), since a job
+committed early in an install (e.g. from a <tt class="docutils literal">post_init_hook</tt>) may reference
+code that doesn’t match the database until the install fully completes.
+Pending states older than <tt class="docutils literal">queue_job.install_in_progress_timeout_minutes</tt>
+(default <tt class="docutils literal">60</tt>) are treated as abandoned and ignored, with a warning
+logged, rather than blocking jobs forever. Disable the check entirely with
+the <tt class="docutils literal">queue_job.check_install_in_progress</tt> system parameter set to
+<tt class="docutils literal">False</tt>.</li>
 </ul>
 </div>
 <div class="section" id="usage">

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -1,12 +1,25 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
+from odoo.modules.module import get_manifest as real_get_manifest
 from odoo.tests.common import TransactionCase
 
+from ..controllers import main as main_module
 from ..controllers.main import RunJobController
 from ..job import Job
 
+_CTRL_MOD = "odoo.addons.queue_job.controllers.main"
+
 
 class TestRunJobController(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        # _worker_is_outdated() caches its verdict in a process-level global,
+        # not per-transaction -- TransactionCase's rollback between tests has
+        # no way to clear it, so each test must start from a clean cache.
+        main_module._modules_up_to_date_cache.clear()
+
     def test_get_failure_values(self):
         method = self.env["res.users"].mapped
         job = Job(method)
@@ -21,3 +34,84 @@ class TestRunJobController(TransactionCase):
         RunJobController._runjob(self.env, job)
         self.assertEqual(job.state, "done")
         self.assertEqual(job.db_record().state, "done")
+
+    def test_runjob_postpones_when_worker_outdated(self):
+        """When the worker's module code is outdated, the job is postponed
+        instead of executed, and _try_perform_job is never reached."""
+        # job.store() here runs inside job.in_temporary_env(), which commits
+        # on its own separate cursor (job.py) so a postponed job survives
+        # even if its own transaction rolls back -- meaning this row also
+        # survives TransactionCase's rollback. Clean it up the same way.
+        job = self.env["queue.job"].with_delay()._test_job()
+        self.addCleanup(self._delete_committed_job, job.uuid)
+        with patch.object(RunJobController, "_worker_is_outdated", return_value=True):
+            with patch.object(RunJobController, "_try_perform_job") as mock_perform:
+                RunJobController._runjob(self.env, job)
+        mock_perform.assert_not_called()
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.db_record().state, "pending")
+
+    def _delete_committed_job(self, uuid):
+        with self.env.registry.cursor() as cr:
+            cr.execute("DELETE FROM queue_job WHERE uuid = %s", (uuid,))
+
+    def test_worker_is_outdated_false_by_default(self):
+        """A freshly installed test DB is never outdated: on-disk versions
+        already match what was recorded in the database."""
+        # A fresh test DB has every installed module's on-disk version
+        # matching what was recorded at install time -- no setup needed.
+        self.assertFalse(RunJobController._worker_is_outdated(self.env))
+
+    def test_worker_is_outdated_true_on_mismatch(self):
+        """A module whose recorded latest_version differs from its on-disk
+        manifest version is detected as outdated."""
+        base = (
+            self.env["ir.module.module"].sudo().search([("name", "=", "base")], limit=1)
+        )
+        base.write({"latest_version": "0.0.0"})
+        self.assertTrue(RunJobController._worker_is_outdated(self.env))
+
+    def test_worker_is_outdated_ignores_unreadable_manifest(self):
+        """A module whose manifest can't be read from disk is skipped, not
+        treated as evidence of staleness."""
+
+        def fake_get_manifest(module_name, mod_path=None):
+            if module_name == "base":
+                return {}
+            return real_get_manifest(module_name, mod_path)
+
+        with patch(_CTRL_MOD + ".get_manifest", side_effect=fake_get_manifest):
+            # "base"'s manifest is unreadable here, but nothing else is
+            # actually mismatched -- must not be treated as outdated.
+            self.assertFalse(RunJobController._worker_is_outdated(self.env))
+
+    def test_worker_is_outdated_disabled_via_config_param(self):
+        """Setting queue_job.check_modules_up_to_date to False skips the
+        check entirely, even with a real version mismatch present."""
+        base = (
+            self.env["ir.module.module"].sudo().search([("name", "=", "base")], limit=1)
+        )
+        base.write({"latest_version": "0.0.0"})
+        self.env["ir.config_parameter"].sudo().set_param(
+            "queue_job.check_modules_up_to_date", "False"
+        )
+        self.assertFalse(RunJobController._worker_is_outdated(self.env))
+
+    def test_worker_is_outdated_result_is_cached(self):
+        """The outdated verdict is cached per database for a few seconds,
+        and only recomputed once that cache entry is expired."""
+        base = (
+            self.env["ir.module.module"].sudo().search([("name", "=", "base")], limit=1)
+        )
+        original_latest_version = base.latest_version
+        base.write({"latest_version": "0.0.0"})
+        self.assertTrue(RunJobController._worker_is_outdated(self.env))
+
+        # Fix the mismatch -- the cached verdict should still say True.
+        base.write({"latest_version": original_latest_version})
+        self.assertTrue(RunJobController._worker_is_outdated(self.env))
+
+        # Force the cache entry to look expired -> recompute -> now False.
+        dbname = self.env.cr.dbname
+        main_module._modules_up_to_date_cache[dbname] = (0.0, True)
+        self.assertFalse(RunJobController._worker_is_outdated(self.env))

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -19,6 +19,15 @@ class TestRunJobController(TransactionCase):
         # not per-transaction -- TransactionCase's rollback between tests has
         # no way to clear it, so each test must start from a clean cache.
         main_module._modules_up_to_date_cache.clear()
+        # When this suite runs as part of installing several modules at once
+        # (e.g. -i queue_job,test_queue_job), a module later in the batch can
+        # genuinely still be 'to install' while queue_job's own tests run --
+        # that's real, unrelated to anything under test here. Normalize to a
+        # clean baseline; individual tests set up their own pending state.
+        self.env.cr.execute(
+            "UPDATE ir_module_module SET state = 'installed' "
+            "WHERE state IN ('to install', 'to upgrade', 'to remove')"
+        )
 
     def test_get_failure_values(self):
         method = self.env["res.users"].mapped
@@ -45,6 +54,18 @@ class TestRunJobController(TransactionCase):
         job = self.env["queue.job"].with_delay()._test_job()
         self.addCleanup(self._delete_committed_job, job.uuid)
         with patch.object(RunJobController, "_worker_is_outdated", return_value=True):
+            with patch.object(RunJobController, "_try_perform_job") as mock_perform:
+                RunJobController._runjob(self.env, job)
+        mock_perform.assert_not_called()
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.db_record().state, "pending")
+
+    def test_runjob_postpones_when_install_in_progress(self):
+        """When modules are being installed/upgraded, the job is postponed
+        instead of executed, and _try_perform_job is never reached."""
+        job = self.env["queue.job"].with_delay()._test_job()
+        self.addCleanup(self._delete_committed_job, job.uuid)
+        with patch.object(RunJobController, "_install_in_progress", return_value=True):
             with patch.object(RunJobController, "_try_perform_job") as mock_perform:
                 RunJobController._runjob(self.env, job)
         mock_perform.assert_not_called()
@@ -115,3 +136,53 @@ class TestRunJobController(TransactionCase):
         dbname = self.env.cr.dbname
         main_module._modules_up_to_date_cache[dbname] = (0.0, True)
         self.assertFalse(RunJobController._worker_is_outdated(self.env))
+
+    def test_install_in_progress_false_by_default(self):
+        """A freshly installed test DB has no module pending install/upgrade/
+        removal -- no setup needed."""
+        self.assertFalse(RunJobController._install_in_progress(self.env))
+
+    def test_install_in_progress_true_when_module_pending(self):
+        """A module marked 'to upgrade' (or 'to install'/'to remove'), with a
+        recent write_date, is detected as an install in progress."""
+        self.env.cr.execute(
+            "UPDATE ir_module_module SET state = 'to upgrade', "
+            "write_date = (now() AT TIME ZONE 'UTC') WHERE name = 'base'"
+        )
+        self.assertTrue(RunJobController._install_in_progress(self.env))
+
+    def test_install_in_progress_ignores_stale_pending_states(self):
+        """A module that has been pending for longer than the configured
+        timeout is treated as an abandoned operation, not an active one."""
+        self.env.cr.execute(
+            "UPDATE ir_module_module SET state = 'to upgrade', "
+            "write_date = (now() AT TIME ZONE 'UTC') - interval '61 minutes' "
+            "WHERE name = 'base'"
+        )
+        with self.assertLogs("odoo.addons.queue_job.controllers.main", level="WARNING"):
+            self.assertFalse(RunJobController._install_in_progress(self.env))
+
+    def test_install_in_progress_disabled_via_config_param(self):
+        """Setting queue_job.check_install_in_progress to False skips the
+        check entirely, even with a module genuinely pending."""
+        self.env.cr.execute(
+            "UPDATE ir_module_module SET state = 'to upgrade', "
+            "write_date = (now() AT TIME ZONE 'UTC') WHERE name = 'base'"
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "queue_job.check_install_in_progress", "False"
+        )
+        self.assertFalse(RunJobController._install_in_progress(self.env))
+
+    def test_install_in_progress_busts_outdated_cache(self):
+        """Detecting an active install clears any cached _worker_is_outdated
+        verdict, so the first job dispatched once the install completes
+        recomputes it freshly instead of reusing a pre-install answer."""
+        dbname = self.env.cr.dbname
+        main_module._modules_up_to_date_cache[dbname] = (0.0, False)
+        self.env.cr.execute(
+            "UPDATE ir_module_module SET state = 'to upgrade', "
+            "write_date = (now() AT TIME ZONE 'UTC') WHERE name = 'base'"
+        )
+        self.assertTrue(RunJobController._install_in_progress(self.env))
+        self.assertNotIn(dbname, main_module._modules_up_to_date_cache)


### PR DESCRIPTION
## Problem

`queue_job`'s jobrunner dispatches pending jobs by issuing an HTTP request to the
instance's configured URL. In a single-process setup that naturally comes back to the
same process, but in any deployment with more than one worker process behind a load
balancer or reverse proxy — for example, multiple pods or containers in a
container-orchestrated setup (Kubernetes, Docker Swarm, or similar) — that URL resolves
to whichever worker happens to be sitting behind the load balancer at that moment. Not
necessarily the worker that enqueued the job, and not necessarily one running the same
code, or even one that agrees with the database on which modules are currently
installed.

### Rolling deployment: worker running stale code

Worker restarts aren't atomic across a fleet: pods/containers get replaced one at a
time, so for some window there are old and new versions running side by side, all
reachable through the same load balancer. The trigger is often the module upgrade
itself: it's a common pattern for a module's upgrade step (a `post_init_hook`, or a
call in a data file) to enqueue a job via `with_delay()` for post-processing that
shouldn't run synchronously inside the upgrade transaction — resyncing data, warming
caches, per-record post-processing, and similar. That job is created as part of the
upgrade, by the worker performing it, which is precisely what sets up the race. A
concrete timeline:

1. Worker A and worker B are both running module version 1.0, serving from the same
   database, both reachable behind the same load balancer.
2. A rolling deployment starts. Worker A restarts first, now running version 1.1, and
   runs the module upgrade (`-u`) against the shared database. As one of its upgrade
   steps, it enqueues a post-processing job via `with_delay()`.
3. Worker B hasn't restarted yet — it's still running version 1.0's code, in memory,
   unaware anything changed.
4. The jobrunner's dispatch request for that job happens to be routed to worker B by
   the load balancer.
5. Worker B executes the job using version 1.0's code, against a database that version
   1.1 has already migrated.

What happens next depends entirely on what that job does — there is no single,
predictable failure mode:

- It can fail outright if the job relies on the new code but executes on the old
  worker — noisy, but at least visible.
- If the job's code path is unaffected by the schema/behavior change directly, but
  reads something version-dependent — a file bundled with the module, a piece of
  business logic that changed for the 1.1 release — it can complete "successfully"
  while producing outdated or subtly wrong results. Nothing raises, nothing logs an
  error, the job reports `done`. This case is the more dangerous one: it isn't caught
  by retries or monitoring, and it can go unnoticed until a symptom shows up somewhere
  else entirely, or until the next upgrade re-triggers the same job and it behaves
  differently (and correctly) the second time.

Both outcomes share the same root cause: the worker executing the job is not
guaranteed to be running the same code as the worker(s) that already updated the
database. This affects any job whose behavior is coupled to the module's own code or
bundled files, which `queue_job` has no way to know about or guard against on its own —
and post-processing jobs enqueued directly from an upgrade step are the most common way
to run straight into it.

### A narrower, earlier window: jobs enqueued *during* the install itself

There's a second, related window that a version check alone can't cover, and it's the
root cause of #882. Core's own module loading
(`odoo/modules/loading.py::load_module_graph()`) commits a module's `post_init_hook`
**before** it commits that module's own `state = 'installed'` / `latest_version`
update. Concretely, for each module being installed/upgraded in a batch: the hook runs
and its commit fires, and only after that (sometimes as part of the *next* module's
commit, sometimes only at the very end of the whole request if it's the last module in
the batch) does the module get marked installed with its new `latest_version`.

If that hook enqueues a job — the same pattern described above — the job can already be
committed and dispatchable to any worker while the database doesn't yet record the
module as installed at all. A version-mismatch check has nothing to compare against in
that window: `latest_version` simply hasn't been written yet, so the job can reach a
worker that has no way to tell it's running against a database still mid-upgrade.

Core already guards against exactly this shape of problem for its own scheduled actions
(`ir_cron._check_modules_state()`,
`odoo/addons/base/models/ir_cron.py`): while any module sits in `'to install'` /
`'to upgrade'` / `'to remove'` state, cron processing is skipped for the whole
database, with a staleness escape for abandoned pending states. `queue_job` dispatches
over HTTP and bypasses `ir_cron` entirely, so it never inherited this protection.

## Proposed fix

Two independent checks in `RunJobController._runjob`, run before a job is performed,
covering the full timeline with an atomic handover between them:

### 1. Worker running outdated module code

Compare each installed module's on-disk version — read fresh from this process via
`get_manifest()` (already `lru_cache`d in core, so this is cheap after the first call)
— against what the database recorded as the installed version during the most recent
successful upgrade (`ir.module.module.latest_version`, written by
`odoo/modules/loading.py` every time a module is actually installed/upgraded by some
process).

A mismatch means some other worker has already upgraded this module past what the
current worker is running.

### 2. Install/upgrade/removal in progress anywhere in the cluster

Port of core's `ir_cron._check_modules_state()`: while any module's
`ir_module_module.state` is `'to install'`, `'to upgrade'`, or `'to remove'`, defer the
job — this is exactly the window described above, where a job may already be committed
and visible while the database hasn't finished recording what it belongs to. Pending
states older than a configurable timeout are treated as abandoned (e.g. a process
crashed mid-install) and ignored, with a warning logged, rather than blocking job
processing forever.

The two checks hand off cleanly: the same commit that clears the last pending module
state also publishes its `latest_version`, so the instant the install-in-progress check
drops, the version check has trustworthy data for any worker still running stale code.

In both cases, the job is deferred through the existing postpone/requeue path instead
of being executed — the checks run before `job.perform()`, so they never consume a
retry attempt and can safely wait out a rollout or install of any length. They resolve
automatically once the relevant worker is replaced/restarted or the install completes,
or sooner if a retry happens to land on a worker/state that's already current.

The version-mismatch verdict is cached briefly per database so a busy queue isn't
re-querying `ir.module.module` on every single job dispatch; the install-in-progress
check is intentionally *not* cached, since it needs to catch a job committed in the
same transaction as the pending state — a cached verdict would reopen that exact race
for the length of the cache window. Detecting an active install also busts the
version-mismatch cache, so the first job dispatched once the install completes
re-checks fresh instead of reusing a pre-install verdict.

## Configuration

- `queue_job.check_modules_up_to_date` (default enabled) — the worker-version check.
  Set to `False` to disable.
- `queue_job.check_install_in_progress` (default enabled) — the install-in-progress
  check. Set to `False` to disable.
- `queue_job.install_in_progress_timeout_minutes` (default `60`) — how long a pending
  module state is trusted before being treated as abandoned.

## Tests

Added coverage for: default (not outdated / nothing pending) behavior, a forced version
mismatch, a module pending install/upgrade/removal, graceful handling of a module whose
manifest can't be read (never treated as evidence of staleness), an abandoned pending
state past the timeout, both config-parameter opt-outs, the short-lived version-check
cache (and its busting by the install-in-progress check), and all three branches of
`_runjob` (install-in-progress deferral, outdated-worker deferral, normal execution).

## Related

Closes/addresses #882.