### PR TITLE
[IMP] queue_job: add MaxRetryJobError

### DIFF
--- a/queue_job/exception.py
+++ b/queue_job/exception.py
@@ -18,6 +18,10 @@ class FailedJobError(JobError):
     """A job had an error having to be resolved."""
 
 
+class MaxRetryJobError(FailedJobError):
+    """A job has hit its maximum number of retries and failed."""
+
+
 class RetryableJobError(JobError):
     """A job had an error but can be retried.
 

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -14,7 +14,7 @@ from random import randint
 
 import odoo
 
-from .exception import FailedJobError, NoSuchJobError, RetryableJobError
+from .exception import MaxRetryJobError, NoSuchJobError, RetryableJobError
 
 WAIT_DEPENDENCIES = "wait_dependencies"
 PENDING = "pending"
@@ -500,7 +500,7 @@ class Job:
                 # change the exception type but keep the original
                 # traceback and message:
                 # http://blog.ianbicking.org/2007/09/12/re-raising-exceptions/
-                new_exc = FailedJobError(
+                new_exc = MaxRetryJobError(
                     "Max. retries (%d) reached: %s" % (self.max_retries, value or type_)
                 )
                 raise new_exc from err

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -10,7 +10,7 @@ import odoo.tests.common as common
 from odoo.addons.queue_job import identity_exact
 from odoo.addons.queue_job.delay import DelayableGraph
 from odoo.addons.queue_job.exception import (
-    FailedJobError,
+    MaxRetryJobError,
     NoSuchJobError,
     RetryableJobError,
 )
@@ -77,7 +77,7 @@ class TestJobsOnTestingMethod(JobCommonCase):
         with self.assertRaises(RetryableJobError):
             test_job.perform()
         self.assertEqual(test_job.retry, 2)
-        with self.assertRaises(FailedJobError):
+        with self.assertRaises(MaxRetryJobError):
             test_job.perform()
         self.assertEqual(test_job.retry, 3)
 


### PR DESCRIPTION
Prior to this change it was impossible to catch the specific case of max retry error w/o ispecting the attributes of the exception.
