### PR TITLE
[IMP] queue_job_cron - allow commit within a cron that runs as queue job

### DIFF
--- a/queue_job_cron/models/ir_cron.py
+++ b/queue_job_cron/models/ir_cron.py
@@ -24,6 +24,13 @@ class IrCron(models.Model):
     run_as_queue_job = fields.Boolean(
         help="Specify if this cron should be ran as a queue job"
     )
+    allow_commit = fields.Boolean(
+        help="Run this cron's server action in a dedicated database cursor "
+        "when executed as a queue job, allowing it to commit partial "
+        "progress during execution. Incurs the overhead of an extra "
+        "database connection. Only effective when 'Run as Queue Job' is "
+        "enabled.",
+    )
     channel_id = fields.Many2one(
         comodel_name="queue.job.channel",
         compute="_compute_run_as_queue_job",
@@ -42,8 +49,18 @@ class IrCron(models.Model):
             else:
                 cron.channel_id = False
 
+    @api.onchange("run_as_queue_job")
+    def _onchange_run_as_queue_job(self):
+        if not self.run_as_queue_job:
+            self.allow_commit = False
+
     def _run_job_as_queue_job(self, server_action):
-        return server_action.run()
+        if not self.allow_commit:
+            return server_action.run()
+        with self.env.registry.cursor() as new_cr:
+            new_env = self.env(cr=new_cr)
+            server_action.with_env(new_env).run()
+        return True
 
     def method_direct_trigger(self):
         for cron in self:

--- a/queue_job_cron/tests/test_queue_job_cron.py
+++ b/queue_job_cron/tests/test_queue_job_cron.py
@@ -1,6 +1,10 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.queue_job.controllers.main import _prevent_commit
 
 
 class TestQueueJobCron(TransactionCase):
@@ -12,6 +16,7 @@ class TestQueueJobCron(TransactionCase):
         default_channel = self.env.ref("queue_job_cron.channel_root_ir_cron")
         cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
         self.assertFalse(cron.run_as_queue_job)
+        self.assertFalse(cron.allow_commit)
 
         cron.method_direct_trigger()
         nb_jobs = QueueJob.search_count([("name", "=", cron.name)])
@@ -82,3 +87,56 @@ class TestQueueJobCron(TransactionCase):
         self.assertEqual(nb_partners_after_cron, nb_partners + 1)
         nb_jobs_after_cron = self.env["queue.job"].search_count([])
         self.assertEqual(nb_jobs_after_cron, nb_jobs + 1)
+
+    def test_queue_job_cron_allow_commit_reset_onchange(self):
+        """Unchecking 'Run as Queue Job' in the form clears allow_commit."""
+        cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
+        with Form(cron) as cron_form:
+            cron_form.run_as_queue_job = True
+            cron_form.allow_commit = True
+            cron_form.run_as_queue_job = False
+            self.assertFalse(cron_form.allow_commit)
+
+    def test_queue_job_cron_commit_forbidden_without_allow_commit(self):
+        """Without allow_commit, the job runs on self.cr - the same
+        cursor _try_perform_job protects with _prevent_commit for any
+        real job execution - so an explicit commit() inside the server
+        action must raise, exactly as it would for a normal job."""
+        partner_model = self.env.ref("base.model_res_partner")
+        action = self.env["ir.actions.server"].create(
+            {
+                "name": "Queue job cron forbidden commit",
+                "state": "code",
+                "model_id": partner_model.id,
+                "crud_model_id": partner_model.id,
+                "code": "env.cr.commit()",
+            }
+        )
+        cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
+        self.assertFalse(cron.allow_commit)
+        with _prevent_commit(self.cr):
+            with self.assertRaisesRegex(ValueError, "Commit is forbidden"):
+                cron._run_job_as_queue_job(server_action=action)
+
+    def test_queue_job_cron_allow_commit_bypasses_forbidden_commit(self):
+        """allow_commit runs on its own dedicated cursor, so it's
+        unaffected by _prevent_commit patching self.cr - this is the
+        whole reason the option exists."""
+        partner_model = self.env.ref("base.model_res_partner")
+        with self.registry.cursor() as setup_cr:
+            setup_env = api.Environment(setup_cr, self.env.uid, {})
+            action = setup_env["ir.actions.server"].create(
+                {
+                    "name": "Queue job cron allow_commit bypasses forbidden commit",
+                    "state": "code",
+                    "model_id": partner_model.id,
+                    "crud_model_id": partner_model.id,
+                    "code": "env.cr.commit()",
+                }
+            )
+            action_id = action.id
+        cron = self.env.ref("queue_job.ir_cron_autovacuum_queue_jobs")
+        cron.write({"allow_commit": True})
+        action = self.env["ir.actions.server"].browse(action_id)
+        with _prevent_commit(self.cr):
+            cron._run_job_as_queue_job(server_action=action)  # must not raise

--- a/queue_job_cron/views/ir_cron_view.xml
+++ b/queue_job_cron/views/ir_cron_view.xml
@@ -11,6 +11,7 @@
                     name="no_parallel_queue_job_run"
                     invisible="not run_as_queue_job"
                 />
+                <field name="allow_commit" invisible="not run_as_queue_job" />
                 <field
                     name="channel_id"
                     invisible="not run_as_queue_job"


### PR DESCRIPTION
Related to https://github.com/OCA/queue/pull/899

Works as the new option on the job function but on the cron, false by default, allow to run the job in a new transaction