### PR TITLE
[19.0][FIX] queue_job: rebind args/kwargs lazily to the job's current cursor

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -13,8 +13,29 @@ from datetime import datetime, timedelta
 from random import randint
 
 import odoo
+from odoo.models import BaseModel
 
 from .exception import FailedJobError, NoSuchJobError, RetryableJobError
+
+
+def _rebind_to_cr(value, cr):
+    """Rebind any BaseModel inside ``value`` to the cursor ``cr``.
+
+    Recurses into lists, tuples and dicts. Preserves uid/su/context of each
+    inner env - only the cursor is swapped. Recordsets already bound to
+    ``cr`` and non-recordset values pass through untouched. Containers are
+    rebuilt, so in-place changes to the result are lost.
+    """
+    if isinstance(value, BaseModel):
+        if value.env.cr is cr:
+            return value
+        return value.with_env(value.env(cr=cr))
+    if isinstance(value, (list, tuple)):
+        return type(value)(_rebind_to_cr(v, cr) for v in value)
+    if isinstance(value, dict):
+        return {k: _rebind_to_cr(v, cr) for k, v in value.items()}
+    return value
+
 
 WAIT_DEPENDENCIES = "wait_dependencies"
 PENDING = "pending"
@@ -513,8 +534,8 @@ class Job:
     def in_temporary_env(self):
         with self.env.registry.cursor() as new_cr:
             env = self.env
-            self._env = env(cr=new_cr)
             try:
+                self._env = env(cr=new_cr)
                 yield
             finally:
                 self._env = env
@@ -687,6 +708,24 @@ class Job:
     @env.setter
     def _env(self, env):
         self.recordset = self.recordset.with_env(env)
+
+    @property
+    def args(self):
+        """Positional arguments, rebound to the job's current cursor."""
+        return _rebind_to_cr(self._args, self.env.cr)
+
+    @args.setter
+    def args(self, value):
+        self._args = value
+
+    @property
+    def kwargs(self):
+        """Keyword arguments, rebound to the job's current cursor."""
+        return _rebind_to_cr(self._kwargs, self.env.cr)
+
+    @kwargs.setter
+    def kwargs(self, value):
+        self._kwargs = value
 
     @property
     def func(self):

--- a/test_queue_job/data/queue_job_function_data.xml
+++ b/test_queue_job/data/queue_job_function_data.xml
@@ -21,6 +21,14 @@
         <field name="retry_pattern" eval="{3: 180}" />
     </record>
     <record
+        id="job_function_test_queue_job_job_commit_with_arg_records"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="test_queue_job.model_test_queue_job" />
+        <field name="method">job_commit_with_arg_records</field>
+        <field name="allow_commit" eval="True" />
+    </record>
+    <record
         id="job_function_test_queue_channel_job_sub_channel"
         model="queue.job.function"
     >

--- a/test_queue_job/models/test_models.py
+++ b/test_queue_job/models/test_models.py
@@ -113,6 +113,19 @@ class ModelTestQueueJob(models.Model):
         mutable_kwarg["b"] = 2
         return mutable_arg, mutable_kwarg
 
+    def job_commit_with_arg_records(
+        self, record, record_list=None, record_dict=None, token=None
+    ):
+        assert record.env.cr is self.env.cr, "record argument cursor was not rebound"
+        assert not record_list or record_list[0].env.cr is self.env.cr, (
+            "record list argument cursor was not rebound"
+        )
+        assert not record_dict or record_dict["record"].env.cr is self.env.cr, (
+            "record dict argument cursor was not rebound"
+        )
+        record.env.cr.commit()  # pylint: disable=invalid-commit
+        return token
+
     def delay_me(self, arg, kwarg=None):
         return arg, kwarg
 

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -9,6 +9,7 @@ import odoo.tests.common as common
 from odoo import Command
 
 from odoo.addons.queue_job import identity_exact
+from odoo.addons.queue_job.controllers.main import RunJobController
 from odoo.addons.queue_job.delay import DelayableGraph
 from odoo.addons.queue_job.exception import (
     FailedJobError,
@@ -83,6 +84,17 @@ class TestJobsOnTestingMethod(JobCommonCase):
         test_job = Job(self.method, args=("o", "k"), kwargs={"c": "!"})
         result = test_job.perform()
         self.assertEqual(result, (("o", "k"), {"c": "!"}))
+
+    def test_allow_commit_rebinds_recordsets_in_args(self):
+        record = self.env.user.partner_id
+        job = (
+            self.env["test.queue.job"]
+            .with_delay()
+            .job_commit_with_arg_records(record, [record], {"record": record}, "ok")
+        )
+        RunJobController._runjob(self.env, job)
+        self.assertEqual(job.state, DONE)
+        self.assertEqual(job.result, "ok")
 
     def test_retryable_error(self):
         test_job = Job(self.method, kwargs={"raise_retry": True}, max_retries=3)


### PR DESCRIPTION
19.0 port of #967, as promised.