### PR TITLE
[18.0][IMP] queue_job: Implement on fail hook

### DIFF
--- a/queue_job/controllers/main.py
+++ b/queue_job/controllers/main.py
@@ -186,6 +186,7 @@ class RunJobController(http.Controller):
                 vals = cls._get_failure_values(job, traceback_txt, orig_exception)
                 job.set_failed(**vals)
                 job.store()
+                job.on_fail(vals)
                 buff.close()
             raise
 

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -409,6 +409,11 @@ class Job:
         self.job_config = (
             self.env["queue.job.function"].sudo().job_config(self.job_function_name)
         )
+        on_fail_method_name = self.job_config.on_fail_method_name
+        if on_fail_method_name:
+            if not _is_model_method(getattr(self.recordset, on_fail_method_name, None)):
+                raise TypeError("Job accepts only methods of Models")
+            self.on_fail_method_name = on_fail_method_name
 
         self.state = PENDING
 
@@ -828,6 +833,11 @@ class Job:
         for k, v in kw.items():
             if v is not None:
                 setattr(self, k, v)
+
+    def on_fail(self, fail_vals):
+        on_fail_func = getattr(self.recordset, self.on_fail_method_name, None)
+        if on_fail_func:
+            on_fail_func(**fail_vals)
 
     def __repr__(self):
         return "<Job %s, priority:%d>" % (self.uuid, self.priority)

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -410,10 +410,11 @@ class Job:
             self.env["queue.job.function"].sudo().job_config(self.job_function_name)
         )
         on_fail_method_name = self.job_config.on_fail_method_name
-        if on_fail_method_name:
-            if not _is_model_method(getattr(self.recordset, on_fail_method_name, None)):
-                raise TypeError("Job accepts only methods of Models")
-            self.on_fail_method_name = on_fail_method_name
+        if on_fail_method_name and not _is_model_method(
+            getattr(self.recordset, on_fail_method_name, None)
+        ):
+            raise TypeError("Job accepts only methods of Models")
+        self.on_fail_method_name = on_fail_method_name
 
         self.state = PENDING
 
@@ -835,6 +836,8 @@ class Job:
                 setattr(self, k, v)
 
     def on_fail(self, fail_vals):
+        if not self.on_fail_method_name:
+            return
         on_fail_func = getattr(self.recordset, self.on_fail_method_name, None)
         if on_fail_func:
             on_fail_func(**fail_vals)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -485,3 +485,6 @@ class QueueJob(models.Model):
             time.sleep(job_duration)
         if commit_within_job:
             self.env.cr.commit()  # pylint: disable=invalid-commit
+
+    def _test_on_fail(self, **kw):
+        pass

--- a/queue_job/models/queue_job_function.py
+++ b/queue_job/models/queue_job_function.py
@@ -29,7 +29,8 @@ class QueueJobFunction(models.Model):
         "related_action_func_name "
         "related_action_kwargs "
         "job_function_id "
-        "allow_commit",
+        "allow_commit "
+        "on_fail_method_name",
     )
 
     def _default_channel(self):
@@ -48,6 +49,10 @@ class QueueJobFunction(models.Model):
         comodel_name="ir.model", string="Model", ondelete="cascade"
     )
     method = fields.Char()
+    on_fail_method = fields.Char(
+        help="Model function to be called if the job is failed and will not be "
+        "retried.",
+    )
 
     channel_id = fields.Many2one(
         comodel_name="queue.job.channel",
@@ -157,6 +162,7 @@ class QueueJobFunction(models.Model):
             related_action_kwargs={},
             job_function_id=None,
             allow_commit=False,
+            on_fail_method_name=None,
         )
 
     def _parse_retry_pattern(self):
@@ -193,6 +199,7 @@ class QueueJobFunction(models.Model):
             related_action_kwargs=config.related_action.get("kwargs", {}),
             job_function_id=config.id,
             allow_commit=config.allow_commit,
+            on_fail_method_name=config.on_fail_method,
         )
 
     def _retry_pattern_format_error_message(self):

--- a/queue_job/tests/test_model_job_function.py
+++ b/queue_job/tests/test_model_job_function.py
@@ -35,6 +35,7 @@ class TestJobFunction(common.TransactionCase):
             {
                 "model_id": self.env.ref("base.model_res_users").id,
                 "method": "read",
+                "on_fail_method": "search_read",
                 "channel_id": channel.id,
                 "edit_retry_pattern": "{1: 2, 3: 4}",
                 "edit_related_action": (
@@ -55,5 +56,6 @@ class TestJobFunction(common.TransactionCase):
                 related_action_kwargs={"b": 1},
                 job_function_id=job_function.id,
                 allow_commit=True,
+                on_fail_method_name="search_read",
             ),
         )

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -1,12 +1,23 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
 
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 from ..controllers.main import RunJobController
+from ..exception import JobError
 from ..job import Job
 
 
 class TestRunJobController(TransactionCase):
+    def setUp(cls):
+        super().setUp()
+
+        def _clean_queue_job():
+            cls.env["queue.job"].search([]).unlink()
+
+        cls.addCleanup(_clean_queue_job)
+
     def test_get_failure_values(self):
         method = self.env["res.users"].mapped
         job = Job(method)
@@ -21,3 +32,20 @@ class TestRunJobController(TransactionCase):
         RunJobController._runjob(self.env, job)
         self.assertEqual(job.state, "done")
         self.assertEqual(job.db_record().state, "done")
+
+    def test_runjob_on_fail(self):
+        function = self.env.ref("queue_job.job_function_queue_job__test_job")
+        function.on_fail_method = "_test_on_fail"
+        job = self.env["queue.job"].with_delay()._test_job(failure_rate=1)
+        with (
+            self.assertRaises(JobError),
+            patch(
+                "odoo.addons.queue_job.models.queue_job.QueueJob._test_on_fail"
+            ) as mocked_hook,
+            patch("odoo.addons.queue_job.job.Job.in_temporary_env") as mocked_temp_env,
+            mute_logger("odoo.addons.queue_job.controllers.main"),
+        ):
+            mocked_temp_env.return_value.__enter__.return_value = self.env
+            RunJobController._runjob(self.env, job)
+            self.assertEqual(job.state, "failed")
+            self.assertEqual(mocked_hook.call_count, 1)

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -49,3 +49,14 @@ class TestRunJobController(TransactionCase):
             RunJobController._runjob(self.env, job)
             self.assertEqual(job.state, "failed")
             self.assertEqual(mocked_hook.call_count, 1)
+
+    def test_runjob_on_fail_not_configured(self):
+        job = self.env["queue.job"].with_delay()._test_job(failure_rate=1)
+        with (
+            self.assertRaises(JobError),
+            patch("odoo.addons.queue_job.job.Job.in_temporary_env") as mocked_temp_env,
+            mute_logger("odoo.addons.queue_job.controllers.main"),
+        ):
+            mocked_temp_env.return_value.__enter__.return_value = self.env
+            RunJobController._runjob(self.env, job)
+        self.assertEqual(job.state, "failed")

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -10,13 +10,13 @@ from ..job import Job
 
 
 class TestRunJobController(TransactionCase):
-    def setUp(cls):
+    def setUp(self):
         super().setUp()
 
         def _clean_queue_job():
-            cls.env["queue.job"].search([]).unlink()
+            self.env["queue.job"].search([]).unlink()
 
-        cls.addCleanup(_clean_queue_job)
+        self.addCleanup(_clean_queue_job)
 
     def test_get_failure_values(self):
         method = self.env["res.users"].mapped

--- a/test_queue_job/tests/test_autovacuum.py
+++ b/test_queue_job/tests/test_autovacuum.py
@@ -51,7 +51,6 @@ class TestQueueJobAutovacuumCronJob(JobCommonCase):
         job_60days.write(
             {"channel": channel_60days.complete_name, "date_done": date_done}
         )
-
         self.assertEqual(
             len(self.env["queue.job"].search([("channel", "!=", False)])), 2
         )


### PR DESCRIPTION
Backport of 
- #955 
- https://github.com/OCA/queue/pull/974

Allows to execute a model function when the job fails and will not be retried.
