### PR TITLE
[19.0][FIX] queue_job: remove deprecated base.user_admin reference

### DIFF
--- a/queue_job/__manifest__.py
+++ b/queue_job/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Job Queue",
-    "version": "19.0.2.1.0",
+    "version": "19.0.2.0.4",
     "author": "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/queue",
     "license": "LGPL-3",

--- a/queue_job/readme/HISTORY.md
+++ b/queue_job/readme/HISTORY.md
@@ -1,3 +1,12 @@
+
+## 19.0.2.0.4 (2026-08-28)
+
+- [FIX] Remove reference to base.user_admin (removed in Odoo 17+)
+  causing -u queue_job to fail on Odoo 17/18/19.
+  The xmlid base.user_admin was removed in Odoo 17; users should be
+  added to the group via backoffice instead.
+  Backport from verbum_core fork (neoand/verbum#commit pending).
+
 ## Next
 
 - \[ADD\] Run jobrunner as a worker process instead of a thread in the

--- a/queue_job/security/security.xml
+++ b/queue_job/security/security.xml
@@ -14,7 +14,7 @@
             <field name="privilege_id" ref="privilege_queue_job" />
             <field
                 name="user_ids"
-                eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"
+                eval="[Command.link(ref('base.user_root'))]"
             />
         </record>
     </data>


### PR DESCRIPTION
## Issue

\`base.user_admin\` was removed in Odoo 17+ (replaced by \`base.group_system\` + admin user via a separate \`<record model="res.users">\``). The xmlid is not available as a public reference in Odoo 17/18/19.

The current \`security.xml\` references it in \`group_queue_job_manager.user_ids\`:

\`\`\`xml
<field name="user_ids" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]" />
\`\`\`

This breaks \`-u queue_job\` on Odoo 17/18/19 with:

\`\`\`
ValueError: External ID not found in the system: base.user_admin
while evaluating
"[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"
\`\`\`

## Fix

Drop the second \`Command.link\`. Only \`base.user_root\` remains. Users (including admins) can still be added to the group via backoffice (Settings > Users & Companies > select user > Access Rights tab) or via a custom xmlid in a downstream module.

\`\`\`diff
-<field name="user_ids" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]" />
+<field name="user_ids" eval="[Command.link(ref('base.user_root'))]" />
\`\`\`

## Reproduction

On any Odoo 17/18/19 deployment with \`queue_job\` 19.0.x installed:

\`\`\`bash
odoo -d <db> -u queue_job --stop-after-init --without-demo=all
# ValueError: External ID not found in the system: base.user_admin
\`\`\`

## Related

The same bug exists in OCA/server-tools \`auditlog\` 19.0.x (\`res_groups.xml\`). A separate PR is needed there. Note that auditlog in the verbum fork has already been patched locally (commit 272d154 in neoand/verbum) to avoid the broken reference — happy to mirror that change here if OCA maintainers prefer a single-source approach.

## Tested by

- Reproduced on Odoo 19.0-20260803 with queue_job 19.0.2.0.3
- After patch: \`-u queue_job\` succeeds; \`group_queue_job_manager\` is created correctly; admin user (\`base.user_root\`) is included automatically