### PR TITLE
[19.0][FIX] queue_job: skip on_fail when unconfigured

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -432,10 +432,11 @@ class Job:
             self.env["queue.job.function"].sudo().job_config(self.job_function_name)
         )
         on_fail_method_name = self.job_config.on_fail_method_name
-        if on_fail_method_name:
-            if not _is_model_method(getattr(self.recordset, on_fail_method_name, None)):
-                raise TypeError("Job accepts only methods of Models")
-            self.on_fail_method_name = on_fail_method_name
+        if on_fail_method_name and not _is_model_method(
+            getattr(self.recordset, on_fail_method_name, None)
+        ):
+            raise TypeError("Job accepts only methods of Models")
+        self.on_fail_method_name = on_fail_method_name
 
         self.state = PENDING
 
@@ -875,6 +876,8 @@ class Job:
                 setattr(self, k, v)
 
     def on_fail(self, fail_vals):
+        if not self.on_fail_method_name:
+            return
         on_fail_func = getattr(self.recordset, self.on_fail_method_name, None)
         if on_fail_func:
             on_fail_func(**fail_vals)

--- a/queue_job/tests/test_run_rob_controller.py
+++ b/queue_job/tests/test_run_rob_controller.py
@@ -49,3 +49,14 @@ class TestRunJobController(TransactionCase):
             RunJobController._runjob(self.env, job)
             self.assertEqual(job.state, "failed")
             self.assertEqual(mocked_hook.call_count, 1)
+
+    def test_runjob_on_fail_not_configured(self):
+        job = self.env["queue.job"].with_delay()._test_job(failure_rate=1)
+        with (
+            self.assertRaises(JobError),
+            patch("odoo.addons.queue_job.job.Job.in_temporary_env") as mocked_temp_env,
+            mute_logger("odoo.addons.queue_job.controllers.main"),
+        ):
+            mocked_temp_env.return_value.__enter__.return_value = self.env
+            RunJobController._runjob(self.env, job)
+        self.assertEqual(job.state, "failed")


### PR DESCRIPTION
Job.on_fail_method_name was only set as an instance attribute when the job function configured on_fail_method, so on_fail() raised AttributeError for every job that didn't opt into it.



Introduced in https://github.com/OCA/queue/pull/955